### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,12 +74,11 @@ This port is written in C++11 and also requires a good C++11 standard library
 (in particular, one with ``regex`` support). The following compilers are known
 to work with docopt:
 
-- clang 3.3 and later
-- gcc 4.9
+- Clang 3.3 and later
+- GCC 4.9
+- Visual C++ 2015 RC
 
-Note that gcc-4.8 will not work due to its missing the ``regex`` module. 
-Note that Visual C++ 2013 will not compile this code, as its C++11 is not
-quite good enough. If a later VC++ works, please let me know!
+Note that GCC-4.8 will not work due to its missing the ``regex`` module. 
 
 This port is licensed under the MIT license, just like the original module.
 However, we are also dual-licensing this code under the Boost License, version 1.0,


### PR DESCRIPTION
Verified successful build & run of the sample application with Visual Studio 2015 RC.
The blocking features -- missing from Visual C++ 2013 -- were unrestricted unions and `noexcept`; they are now supported:
http://blogs.msdn.com/b/vcblog/archive/2015/04/29/c-11-14-17-features-in-vs-2015-rc.aspx

Also fixed the capitalization -- `GCC` refers to the GNU Compiler Collection (including `gcc` -- a C compiler; and `g++` -- a C++ compiler). Previous wording suggested that `gcc` (the C -- not C++ -- compiler) was supported.