### PR TITLE
Parsefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,16 @@ endif()
 # example
 
 if (WITH_TESTS)
-	add_executable(docopt_testcase run_testcase.cpp)
-	target_link_libraries(docopt_testcase docopt)
+	set(TESTPROG "${CMAKE_CURRENT_BINARY_DIR}/run_testcase")
+	set(TESTCASES "${PROJECT_SOURCE_DIR}/testcases.docopt")
+	add_executable(run_testcase run_testcase.cpp)
+	target_link_libraries(run_testcase docopt)
+	configure_file(
+		"${PROJECT_SOURCE_DIR}/run_tests.py"
+		"${CMAKE_CURRENT_BINARY_DIR}/run_tests"
+		ESCAPE_QUOTES
+	)
+	add_test("Testcases docopt" ${TESTPROG})
 endif()
 
 ########################################################################

--- a/docopt.cpp
+++ b/docopt.cpp
@@ -173,7 +173,7 @@ Option Option::parse(std::string const& option_description)
 		options_end = option_description.begin() + double_space;
 	}
 	
-	static const std::regex pattern {"(--|-)?(.*?)([,= ]|$)"};
+	static const std::regex pattern {"(--|-)?([^-].*?)([,= ]+|$)"};
 	for(std::sregex_iterator i {option_description.begin(), options_end, pattern, std::regex_constants::match_not_null},
 	       e{};
 	    i != e;

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,8 +1,10 @@
+#!/usr/bin/env python2
+
 import re
 import json
 import subprocess
 
-executable = "./run_testcase"
+executable = "${TESTPROG}"
 
 def parse_test(raw):
 	raw = re.compile('#.*$', re.M).sub('', raw).strip()
@@ -24,7 +26,7 @@ def parse_test(raw):
 failures = 0
 passes = 0
 
-tests = open('testcases.docopt','r').read()
+tests = open('${TESTCASES}','r').read()
 for _, doc, cases in parse_test(tests):
 	if not cases: continue
 	


### PR DESCRIPTION
See issue #9. With gcc-4.9.2 a lot of testcases fails. With this patch only 2 fails.
