### PR TITLE
Fix several parsing issues + association of short and long options

### DIFF
--- a/docopt.cpp
+++ b/docopt.cpp
@@ -468,7 +468,7 @@ public:
 			"("
 			"\\S*<.*?>"  // strings, but make sure to keep "< >" strings together
 			"|"
-			"\\S+"     // string without <>
+			"[^<>\\s]+"     // string without <>
 			")" };
 
 		// We do two stages of regex matching. The '[]()' and '...' are strong delimeters

--- a/docopt.cpp
+++ b/docopt.cpp
@@ -47,7 +47,7 @@ void value::throwIfNotKind(Kind expected) const
 {
 	if (kind == expected)
 		return;
-	
+
 	std::string error = "Illegal cast to ";
 	error += kindAsString(expected);
 	error += "; type is actually ";
@@ -98,7 +98,7 @@ bool Required::match(PatternList& left, std::vector<std::shared_ptr<LeafPattern>
 {
 	auto l = left;
 	auto c = collected;
-	
+
 	for(auto const& pattern : fChildren) {
 		bool ret = pattern->match(l, c);
 		if (!ret) {
@@ -106,7 +106,7 @@ bool Required::match(PatternList& left, std::vector<std::shared_ptr<LeafPattern>
 			return false;
 		}
 	}
-	
+
 	left = std::move(l);
 	collected = std::move(c);
 	return true;
@@ -118,9 +118,9 @@ bool LeafPattern::match(PatternList& left, std::vector<std::shared_ptr<LeafPatte
 	if (!match.second) {
 		return false;
 	}
-	
+
 	left.erase(left.begin()+match.first);
-	
+
 	auto same_name = std::find_if(collected.begin(), collected.end(), [&](std::shared_ptr<LeafPattern> const& p) {
 		return p->name()==name();
 	});
@@ -144,7 +144,7 @@ bool LeafPattern::match(PatternList& left, std::vector<std::shared_ptr<LeafPatte
 		} else {
 			/// cant be!?
 		}
-		
+
 		if (same_name == collected.end()) {
 			collected.push_back(match.second);
 			match.second->setValue(value{val});
@@ -166,14 +166,14 @@ Option Option::parse(std::string const& option_description)
 	std::string shortOption, longOption;
 	int argcount = 0;
 	value val { false };
-	
+
 	auto double_space = option_description.find("  ");
 	auto options_end = option_description.end();
 	if (double_space != std::string::npos) {
 		options_end = option_description.begin() + double_space;
 	}
-	
-	static const std::regex pattern {"(--|-)?(.*?)([,= ]|$)"};
+
+	static const std::regex pattern {"(-{1,2})?(.*?)([,= ]|$)"};
 	for(std::sregex_iterator i {option_description.begin(), options_end, pattern, std::regex_constants::match_not_null},
 	       e{};
 	    i != e;
@@ -182,9 +182,9 @@ Option Option::parse(std::string const& option_description)
 		std::smatch const& match = *i;
 		if (match[1].matched) { // [1] is optional.
 			if (match[1].length()==1) {
-				shortOption = "-" + match[2].str();
+					shortOption = "-" + match[2].str();
 			} else {
-				longOption =  "--" + match[2].str();
+					longOption =  "--" + match[2].str();
 			}
 		} else if (match[2].length() > 0) { // [2] always matches.
 			std::string m = match[2];
@@ -210,7 +210,7 @@ Option Option::parse(std::string const& option_description)
 			val = match[1].str();
 		}
 	}
-	
+
 	return {std::move(shortOption),
 		std::move(longOption),
 		argcount,
@@ -220,36 +220,36 @@ Option Option::parse(std::string const& option_description)
 bool OneOrMore::match(PatternList& left, std::vector<std::shared_ptr<LeafPattern>>& collected) const
 {
 	assert(fChildren.size() == 1);
-	
+
 	auto l = left;
 	auto c = collected;
-	
+
 	bool matched = true;
 	size_t times = 0;
-	
+
 	decltype(l) l_;
 	bool firstLoop = true;
-	
+
 	while (matched) {
 		// could it be that something didn't match but changed l or c?
 		matched = fChildren[0]->match(l, c);
-		
+
 		if (matched)
 			++times;
-		
+
 		if (firstLoop) {
 			firstLoop = false;
 		} else if (l == l_) {
 			break;
 		}
-		
+
 		l_ = l;
 	}
-	
+
 	if (times == 0) {
 		return false;
 	}
-	
+
 	left = std::move(l);
 	collected = std::move(c);
 	return true;
@@ -258,9 +258,9 @@ bool OneOrMore::match(PatternList& left, std::vector<std::shared_ptr<LeafPattern
 bool Either::match(PatternList& left, std::vector<std::shared_ptr<LeafPattern>>& collected) const
 {
 	using Outcome = std::pair<PatternList, std::vector<std::shared_ptr<LeafPattern>>>;
-	
+
 	std::vector<Outcome> outcomes;
-	
+
 	for(auto const& pattern : fChildren) {
 		// need a copy so we apply the same one for every iteration
 		auto l = left;
@@ -270,16 +270,16 @@ bool Either::match(PatternList& left, std::vector<std::shared_ptr<LeafPattern>>&
 			outcomes.emplace_back(std::move(l), std::move(c));
 		}
 	}
-	
+
 	auto min = std::min_element(outcomes.begin(), outcomes.end(), [](Outcome const& o1, Outcome const& o2) {
 		return o1.first.size() < o2.first.size();
 	});
-	
+
 	if (min == outcomes.end()) {
 		// (left, collected) unchanged
 		return false;
 	}
-	
+
 	std::tie(left, collected) = std::move(*min);
 	return true;
 }
@@ -287,7 +287,7 @@ bool Either::match(PatternList& left, std::vector<std::shared_ptr<LeafPattern>>&
 std::pair<size_t, std::shared_ptr<LeafPattern>> Argument::single_match(PatternList const& left) const
 {
 	std::pair<size_t, std::shared_ptr<LeafPattern>> ret {};
-	
+
 	for(size_t i = 0, size = left.size(); i < size; ++i)
 	{
 		auto arg = dynamic_cast<Argument const*>(left[i].get());
@@ -297,14 +297,14 @@ std::pair<size_t, std::shared_ptr<LeafPattern>> Argument::single_match(PatternLi
 			break;
 		}
 	}
-	
+
 	return ret;
 }
 
 std::pair<size_t, std::shared_ptr<LeafPattern>> Command::single_match(PatternList const& left) const
 {
 	std::pair<size_t, std::shared_ptr<LeafPattern>> ret {};
-	
+
 	for(size_t i = 0, size = left.size(); i < size; ++i)
 	{
 		auto arg = dynamic_cast<Argument const*>(left[i].get());
@@ -316,14 +316,14 @@ std::pair<size_t, std::shared_ptr<LeafPattern>> Command::single_match(PatternLis
 			break;
 		}
 	}
-	
+
 	return ret;
 }
 
 std::pair<size_t, std::shared_ptr<LeafPattern>> Option::single_match(PatternList const& left) const
 {
 	std::pair<size_t, std::shared_ptr<LeafPattern>> ret {};
-	
+
 	for(size_t i = 0, size = left.size(); i < size; ++i)
 	{
 		auto leaf = std::dynamic_pointer_cast<LeafPattern>(left[i]);
@@ -333,7 +333,7 @@ std::pair<size_t, std::shared_ptr<LeafPattern>> Option::single_match(PatternList
 			break;
 		}
 	}
-	
+
 	return ret;
 }
 
@@ -351,13 +351,13 @@ void BranchPattern::fix_repeating_arguments()
 		for(auto const& e : group_set) {
 			if (group_set.count(e) == 1)
 				continue;
-			
+
 			LeafPattern* leaf = dynamic_cast<LeafPattern*>(e.get());
 			if (!leaf) continue;
-			
+
 			bool ensureList = false;
 			bool ensureInt = false;
-			
+
 			if (dynamic_cast<Command*>(leaf)) {
 				ensureInt = true;
 			} else if (dynamic_cast<Argument*>(leaf)) {
@@ -369,7 +369,7 @@ void BranchPattern::fix_repeating_arguments()
 					ensureInt = true;
 				}
 			}
-			
+
 			if (ensureList) {
 				std::vector<std::string> newValue;
 				if (leaf->getValue().isString()) {
@@ -388,37 +388,37 @@ void BranchPattern::fix_repeating_arguments()
 std::vector<PatternList> transform(PatternList pattern)
 {
 	std::vector<PatternList> result;
-	
+
 	std::vector<PatternList> groups;
 	groups.emplace_back(std::move(pattern));
-	
+
 	while(!groups.empty()) {
 		// pop off the first element
 		auto children = std::move(groups[0]);
 		groups.erase(groups.begin());
-		
+
 		// find the first branch node in the list
 		auto child_iter = std::find_if(children.begin(), children.end(), [](std::shared_ptr<Pattern> const& p) {
 			return dynamic_cast<BranchPattern const*>(p.get());
 		});
-		
+
 		// no branch nodes left : expansion is complete for this grouping
 		if (child_iter == children.end()) {
 			result.emplace_back(std::move(children));
 			continue;
 		}
-		
+
 		// pop the child from the list
 		auto child = std::move(*child_iter);
 		children.erase(child_iter);
-		
+
 		// expand the branch in the appropriate way
 		if (Either* either = dynamic_cast<Either*>(child.get())) {
 			// "[e] + children" for each child 'e' in Either
 			for(auto const& eitherChild : either->children()) {
 				PatternList group = { eitherChild };
 				group.insert(group.end(), children.begin(), children.end());
-				
+
 				groups.emplace_back(std::move(group));
 			}
 		} else if (OneOrMore* oneOrMore = dynamic_cast<OneOrMore*>(child.get())) {
@@ -427,19 +427,19 @@ std::vector<PatternList> transform(PatternList pattern)
 			PatternList group = subchildren;
 			group.insert(group.end(), subchildren.begin(), subchildren.end());
 			group.insert(group.end(), children.begin(), children.end());
-			
+
 			groups.emplace_back(std::move(group));
 		} else { // Required, Optional, OptionsShortcut
 			BranchPattern* branch = dynamic_cast<BranchPattern*>(child.get());
-			
+
 			// child.children + children
 			PatternList group = branch->children();
 			group.insert(group.end(), children.begin(), children.end());
-			
+
 			groups.emplace_back(std::move(group));
 		}
 	}
-	
+
 	return result;
 }
 
@@ -449,11 +449,11 @@ public:
 	: fTokens(std::move(tokens)),
 	  fIsParsingArgv(isParsingArgv)
 	{}
-	
+
 	explicit operator bool() const {
 		return fIndex < fTokens.size();
 	}
-	
+
 	static Tokens from_pattern(std::string const& source) {
 		static const std::regex re_separators {
 			"(?:\\s*)" // any spaces (non-matching subgroup)
@@ -462,7 +462,7 @@ public:
 			"|"
 			"\\.\\.\\."  // elipsis
 			")" };
-		
+
 		static const std::regex re_strings {
 			"(?:\\s*)" // any spaces (non-matching subgroup)
 			"("
@@ -470,13 +470,13 @@ public:
 			"|"
 			"\\S+"     // string without <>
 			")" };
-		
+
 		// We do two stages of regex matching. The '[]()' and '...' are strong delimeters
 		// and need to be split out anywhere they occur (even at the end of a token). We
 		// first split on those, and then parse the stuff between them to find the string
 		// tokens. This is a little harder than the python version, since they have regex.split
 		// and we dont have anything like that.
-		
+
 		std::vector<std::string> tokens;
 		std::for_each(std::sregex_iterator{ source.begin(), source.end(), re_separators },
 			      std::sregex_iterator{},
@@ -491,24 +491,24 @@ public:
 								    tokens.push_back(m[1].str());
 							    });
 				      }
-				      
+
 				      // handle the delimter token itself
 				      if (match[1].matched) {
 					      tokens.push_back(match[1].str());
 				      }
 			      });
-		
+
 		return Tokens(tokens, false);
 	}
-	
+
 	std::string const& current() const {
 		if (*this)
 			return fTokens[fIndex];
-		
+
 		static std::string const empty;
 		return empty;
 	}
-	
+
 	std::string the_rest() const {
 		if (!*this)
 			return {};
@@ -516,28 +516,28 @@ public:
 			    fTokens.end(),
 			    " ");
 	}
-	
+
 	std::string pop() {
 		return std::move(fTokens.at(fIndex++));
 	}
-	
+
 	bool isParsingArgv() const { return fIsParsingArgv; }
-	
+
 	struct OptionError : std::runtime_error { using runtime_error::runtime_error; };
-	
+
 private:
 	std::vector<std::string> fTokens;
 	size_t fIndex = 0;
 	bool fIsParsingArgv;
 };
-		
+
 // Get all instances of 'T' from the pattern
 template <typename T>
 std::vector<T*> flat_filter(Pattern& pattern) {
 	std::vector<Pattern*> flattened = pattern.flat([](Pattern const* p) -> bool {
 		return dynamic_cast<T const*>(p);
 	});
-	
+
 	// now, we're guaranteed to have T*'s, so just use static_cast
 	std::vector<T*> ret;
 	std::transform(flattened.begin(), flattened.end(), std::back_inserter(ret), [](Pattern* p) {
@@ -559,7 +559,7 @@ std::vector<std::string> parse_section(std::string const& name, std::string cons
 		")",
 		std::regex::icase
 	};
-	
+
 	std::vector<std::string> ret;
 	std::for_each(std::sregex_iterator(source.begin(), source.end(), re_section_pattern),
 		      std::sregex_iterator(),
@@ -567,20 +567,20 @@ std::vector<std::string> parse_section(std::string const& name, std::string cons
 	{
 		ret.push_back(trim(match[1].str()));
 	});
-	
+
 	return ret;
 }
 
 bool is_argument_spec(std::string const& token) {
 	if (token.empty())
 		return false;
-	
+
 	if (token[0]=='<' && token[token.size()-1]=='>')
 		return true;
-	
+
 	if (std::all_of(token.begin(), token.end(), &::isupper))
 		return true;
-	
+
 	return false;
 }
 
@@ -599,20 +599,20 @@ PatternList parse_long(Tokens& tokens, std::vector<Option>& options)
 	std::string longOpt, equal;
 	value val;
 	std::tie(longOpt, equal, val) = partition(tokens.pop(), "=");
-	
+
 	assert(starts_with(longOpt, "--"));
-	
+
 	if (equal.empty()) {
 		val = value{};
 	}
-	
+
 	// detect with options match this long option
 	std::vector<Option const*> similar;
 	for(auto const& option : options) {
 		if (option.longOption()==longOpt)
 			similar.push_back(&option);
 	}
-	
+
 	// maybe allow similar options that match by prefix
 	if (tokens.isParsingArgv() && similar.empty()) {
 		for(auto const& option : options) {
@@ -622,9 +622,9 @@ PatternList parse_long(Tokens& tokens, std::vector<Option>& options)
 				similar.push_back(&option);
 		}
 	}
-	
+
 	PatternList ret;
-	
+
 	if (similar.size() > 1) { // might be simply specified ambiguously 2+ times?
 		std::vector<std::string> prefixes = longOptions(similar.begin(), similar.end());
 		std::string error = "'" + longOpt + "' is not a unique prefix: ";
@@ -633,7 +633,7 @@ PatternList parse_long(Tokens& tokens, std::vector<Option>& options)
 	} else if (similar.empty()) {
 		int argcount = equal.empty() ? 0 : 1;
 		options.emplace_back("", longOpt, argcount);
-		
+
 		auto o = std::make_shared<Option>(options.back());
 		if (tokens.isParsingArgv()) {
 			o->setValue(argcount ? value{val} : value{true});
@@ -661,40 +661,40 @@ PatternList parse_long(Tokens& tokens, std::vector<Option>& options)
 		}
 		ret.push_back(o);
 	}
-	
+
 	return ret;
 }
 
 PatternList parse_short(Tokens& tokens, std::vector<Option>& options)
 {
 	// shorts ::= '-' ( chars )* [ [ ' ' ] chars ] ;
-	
+
 	auto token = tokens.pop();
-	
+
 	assert(starts_with(token, "-"));
 	assert(!starts_with(token, "--"));
-	
+
 	auto i = token.begin();
 	++i; // skip the leading '-'
-	
+
 	PatternList ret;
 	while (i != token.end()) {
 		std::string shortOpt = { '-', *i };
 		++i;
-		
+
 		std::vector<Option const*> similar;
 		for(auto const& option : options) {
 			if (option.shortOption()==shortOpt)
 				similar.push_back(&option);
 		}
-		
+
 		if (similar.size() > 1) {
 			std::string error = shortOpt + " is specified ambiguously "
 			+ std::to_string(similar.size()) + " times";
 			throw Tokens::OptionError(std::move(error));
 		} else if (similar.empty()) {
 			options.emplace_back(shortOpt, "", 0);
-			
+
 			auto o = std::make_shared<Option>(options.back());
 			if (tokens.isParsingArgv()) {
 				o->setValue(value{true});
@@ -718,14 +718,14 @@ PatternList parse_short(Tokens& tokens, std::vector<Option>& options)
 					i = token.end();
 				}
 			}
-			
+
 			if (tokens.isParsingArgv()) {
 				o->setValue(val ? std::move(val) : value{true});
 			}
 			ret.push_back(o);
 		}
 	}
-	
+
 	return ret;
 }
 
@@ -735,32 +735,32 @@ PatternList parse_atom(Tokens& tokens, std::vector<Option>& options)
 {
 	// atom ::= '(' expr ')' | '[' expr ']' | 'options'
 	//             | long | shorts | argument | command ;
-	
+
 	std::string const& token = tokens.current();
-	
+
 	PatternList ret;
-	
+
 	if (token == "[") {
 		tokens.pop();
-		
+
 		auto expr = parse_expr(tokens, options);
-		
+
 		auto trailing = tokens.pop();
 		if (trailing != "]") {
 			throw DocoptLanguageError("Mismatched '['");
 		}
-		
+
 		ret.emplace_back(std::make_shared<Optional>(std::move(expr)));
 	} else if (token=="(") {
 		tokens.pop();
-		
+
 		auto expr = parse_expr(tokens, options);
-		
+
 		auto trailing = tokens.pop();
 		if (trailing != ")") {
 			throw DocoptLanguageError("Mismatched '('");
 		}
-		
+
 		ret.emplace_back(std::make_shared<Required>(std::move(expr)));
 	} else if (token == "options") {
 		tokens.pop();
@@ -774,22 +774,22 @@ PatternList parse_atom(Tokens& tokens, std::vector<Option>& options)
 	} else {
 		ret.emplace_back(std::make_shared<Command>(tokens.pop()));
 	}
-	
+
 	return ret;
 }
 
 PatternList parse_seq(Tokens& tokens, std::vector<Option>& options)
 {
 	// seq ::= ( atom [ '...' ] )* ;"""
-	
+
 	PatternList ret;
-	
+
 	while (tokens) {
 		auto const& token = tokens.current();
-		
+
 		if (token=="]" || token==")" || token=="|")
 			break;
-		
+
 		auto atom = parse_atom(tokens, options);
 		if (tokens.current() == "...") {
 			ret.emplace_back(std::make_shared<OneOrMore>(std::move(atom)));
@@ -798,7 +798,7 @@ PatternList parse_seq(Tokens& tokens, std::vector<Option>& options)
 			std::move(atom.begin(), atom.end(), std::back_inserter(ret));
 		}
 	}
-	
+
 	return ret;
 }
 
@@ -821,21 +821,21 @@ std::shared_ptr<Pattern> maybe_collapse_to_either(PatternList&& seq)
 PatternList parse_expr(Tokens& tokens, std::vector<Option>& options)
 {
 	// expr ::= seq ( '|' seq )* ;
-	
+
 	auto seq = parse_seq(tokens, options);
-	
+
 	if (tokens.current() != "|")
 		return seq;
-	
+
 	PatternList ret;
 	ret.emplace_back(maybe_collapse_to_required(std::move(seq)));
-	
+
 	while (tokens.current() == "|") {
 		tokens.pop();
 		seq = parse_seq(tokens, options);
 		ret.emplace_back(maybe_collapse_to_required(std::move(seq)));
 	}
-	
+
 	return { maybe_collapse_to_either(std::move(ret)) };
 }
 
@@ -843,10 +843,10 @@ Required parse_pattern(std::string const& source, std::vector<Option>& options)
 {
 	auto tokens = Tokens::from_pattern(source);
 	auto result = parse_expr(tokens, options);
-	
+
 	if (tokens)
 		throw DocoptLanguageError("Unexpected ending: '" + tokens.the_rest() + "'");
-	
+
 	assert(result.size() == 1  &&  "top level is always one big");
 	return Required{ std::move(result) };
 }
@@ -854,7 +854,7 @@ Required parse_pattern(std::string const& source, std::vector<Option>& options)
 
 std::string formal_usage(std::string const& section) {
 	std::string ret = "(";
-	
+
 	auto i = section.find(':')+1;  // skip past "usage:"
 	auto parts = split(section, i);
 	for(size_t i = 1; i < parts.size(); ++i) {
@@ -865,7 +865,7 @@ std::string formal_usage(std::string const& section) {
 			ret += parts[i];
 		}
 	}
-	
+
 	ret += " )";
 	return ret;
 }
@@ -878,11 +878,11 @@ PatternList parse_argv(Tokens tokens, std::vector<Option>& options, bool options
 	//    argv ::= [ long | shorts ]* [ argument ]* [ '--' [ argument ]* ] ;
 	// else:
 	//    argv ::= [ long | shorts | argument ]* [ '--' [ argument ]* ] ;
-	
+
 	PatternList ret;
 	while (tokens) {
 		auto const& token = tokens.current();
-		
+
 		if (token=="--") {
 			// option list is done; convert all the rest to arguments
 			while (tokens) {
@@ -903,7 +903,7 @@ PatternList parse_argv(Tokens tokens, std::vector<Option>& options, bool options
 			ret.emplace_back(std::make_shared<Argument>("", tokens.pop()));
 		}
 	}
-	
+
 	return ret;
 }
 
@@ -916,24 +916,24 @@ std::vector<Option> parse_defaults(std::string const& doc) {
 		"(-(.|\\n)*?)"      // a hyphen, and then grab everything it can...
 		"(?=\\n[ \\t]*-|$)" //  .. until it hits another new line with space and a hyphen
 	};
-	
+
 	std::vector<Option> defaults;
-	
+
 	for(auto s : parse_section("options:", doc)) {
 		s.erase(s.begin(), s.begin()+s.find(':')+1); // get rid of "options:"
-		
+
 		std::for_each(std::sregex_iterator{ s.begin(), s.end(), pattern },
 			      std::sregex_iterator{},
 			      [&](std::smatch const& m)
 		{
 			std::string opt = m[1].str();
-			
+
 			if (starts_with(opt, "-")) {
 				defaults.emplace_back(Option::parse(opt));
 			}
 		});
 	}
-	
+
 	return defaults;
 }
 
@@ -951,7 +951,7 @@ void extras(bool help, bool version, PatternList const& options) {
 	if (help && isOptionSet(options, "-h", "--help")) {
 		throw DocoptExitHelp();
 	}
-	
+
 	if (version && isOptionSet(options, "--version")) {
 		throw DocoptExitVersion();
 	}
@@ -967,19 +967,19 @@ std::pair<Required, std::vector<Option>> create_pattern_tree(std::string const& 
 	if (usage_sections.size() > 1) {
 		throw DocoptLanguageError("More than one 'usage:' (case-insensitive).");
 	}
-	
+
 	std::vector<Option> options = parse_defaults(doc);
 	Required pattern = parse_pattern(formal_usage(usage_sections[0]), options);
-	
+
 	std::vector<Option const*> pattern_options = flat_filter<Option const>(pattern);
-	
+
 	using UniqueOptions = std::unordered_set<Option const*, PatternHasher, PatternPointerEquality>;
 	UniqueOptions const uniq_pattern_options { pattern_options.begin(), pattern_options.end() };
-	
+
 	// Fix up any "[options]" shortcuts with the actual option tree
 	for(auto& options_shortcut : flat_filter<OptionsShortcut>(pattern)) {
 		std::vector<Option> doc_options = parse_defaults(doc);
-		
+
 		// set(doc_options) - set(pattern_options)
 		UniqueOptions uniq_doc_options;
 		for(auto const& opt : doc_options) {
@@ -987,7 +987,7 @@ std::pair<Required, std::vector<Option>> create_pattern_tree(std::string const& 
 				continue;
 			uniq_doc_options.insert(&opt);
 		}
-		
+
 		// turn into shared_ptr's and set as children
 		PatternList children;
 		std::transform(uniq_doc_options.begin(), uniq_doc_options.end(),
@@ -996,7 +996,7 @@ std::pair<Required, std::vector<Option>> create_pattern_tree(std::string const& 
 			       });
 		options_shortcut->setChildren(std::move(children));
 	}
-	
+
 	return { std::move(pattern), std::move(options) };
 }
 
@@ -1014,41 +1014,41 @@ docopt::docopt_parse(std::string const& doc,
 	} catch (Tokens::OptionError const& error) {
 		throw DocoptLanguageError(error.what());
 	}
-	
+
 	PatternList argv_patterns;
 	try {
 		argv_patterns = parse_argv(Tokens(argv), options, options_first);
 	} catch (Tokens::OptionError const& error) {
 		throw DocoptArgumentError(error.what());
 	}
-	
+
 	extras(help, version, argv_patterns);
-	
+
 	std::vector<std::shared_ptr<LeafPattern>> collected;
 	bool matched = pattern.fix().match(argv_patterns, collected);
 	if (matched && argv_patterns.empty()) {
 		std::map<std::string, value> ret;
-		
+
 		// (a.name, a.value) for a in (pattern.flat() + collected)
 		for (auto* p : pattern.leaves()) {
 			ret[p->name()] = p->getValue();
 		}
-		
+
 		for (auto const& p : collected) {
 			ret[p->name()] = p->getValue();
 		}
-		
+
 		return ret;
 	}
-	
+
 	if (matched) {
 		std::string leftover = join(argv.begin(), argv.end(), ", ");
 		throw DocoptArgumentError("Unexpected argument: " + leftover);
 	}
-	
+
 	throw DocoptArgumentError("Arguments did not match expected patterns"); // BLEH. Bad error.
 }
-		
+
 std::map<std::string, value>
 docopt::docopt(std::string const& doc,
 	       std::vector<std::string> const& argv,


### PR DESCRIPTION
Hi,

That patch fixes the following:

* when an option name between <> contains space, it's not handled correctly
* long option is detected as a short option
* default value is not detected
* when a long and short options are possible, they are not put together

In the last case, the value set for the passed version is also assigned to its companion: for instance, if "-h, --help" are defined, if we pass only "-h", both "-h" and "--help" are set to true. The inverse is also true. I didn't find if it was or not the behavior expected, but I considered as a bug.

I've also updated the test cases to take into account that long and short options are associated.

what do you think of it?