### PR TITLE
Fix to allow a new line in the Option definition.

### DIFF
--- a/docopt.cpp
+++ b/docopt.cpp
@@ -173,7 +173,7 @@ Option Option::parse(std::string const& option_description)
 		options_end = option_description.begin() + double_space;
 	}
 	
-	static const std::regex pattern {"(--|-)?(.*?)([,= ]|$)"};
+	static const std::regex pattern {"(--|-)?(.*?)([,= \\n]|$)"};
 	for(std::sregex_iterator i {option_description.begin(), options_end, pattern, std::regex_constants::match_not_null},
 	       e{};
 	    i != e;


### PR DESCRIPTION
Hi, 

thanks for the good work on docopt.cpp.

I've submitted few pull requests to address some problems I've found while using docopt.cpp in our application.

This is again a simillar problem to  pull request #23. Perhaps I should have squashed them together...

The problem manifests on platforms where '$' does not match new line e.g. Linux.

According to:

  http://cplusplus.github.io/LWG/lwg-active.html#2343

some RegEx implementations e.g. GCC have multiline property turned off so '$' does not match a new line character and the Option parser fails to recognise an option's parameter if it is present.

All test are passing on gcc 5.1 and msvc2015.

Regards,
Roman

Failing example:

```
Usage:
    my_app [--so-long-option-that-the-description-is-on-a-new-line <param>]

Options:
    --so-long-option-that-the-description-is-on-a-new-line <param>
                         Something very important [default: 43]
```

modified:   docopt.cpp
