### PR TITLE
Fixes parsing of [default: x] in some cases on Win.

### DIFF
--- a/docopt.cpp
+++ b/docopt.cpp
@@ -908,32 +908,24 @@ PatternList parse_argv(Tokens tokens, std::vector<Option>& options, bool options
 }
 
 std::vector<Option> parse_defaults(std::string const& doc) {
-	// This pattern is a bit more complex than the python docopt one due to lack of
-	// re.split. Effectively, it grabs any line with leading whitespace and then a
-	// hyphen; it stops grabbing when it hits another line that also looks like that.
-	static std::regex const pattern {
+	// This pattern is a delimiter by which we split the options.
+	// The delimiter is a new line followed by a whitespace(s) followed by one or two hyphens.
+	static std::regex const re_delimiter{
 		"(?:^|\\n)[ \\t]*"  // a new line with leading whitespace
-		"(-(.|\\n)*?)"      // a hyphen, and then grab everything it can...
-		"(?=\\n[ \\t]*-|$)" //  .. until it hits another new line with space and a hyphen
+		"(?=-{1,2})"        // [split happens here] (positive lookahead) ... and followed by one or two hyphes
 	};
-	
+
 	std::vector<Option> defaults;
-	
-	for(auto s : parse_section("options:", doc)) {
-		s.erase(s.begin(), s.begin()+s.find(':')+1); // get rid of "options:"
+
+	for (auto s : parse_section("options:", doc)) {
+		s.erase(s.begin(), s.begin() + s.find(':') + 1); // get rid of "options:"
 		
-		std::for_each(std::sregex_iterator{ s.begin(), s.end(), pattern },
-			      std::sregex_iterator{},
-			      [&](std::smatch const& m)
-		{
-			std::string opt = m[1].str();
-			
+		for (const auto& opt : regex_split(s, re_delimiter)) {
 			if (starts_with(opt, "-")) {
 				defaults.emplace_back(Option::parse(opt));
 			}
-		});
+		}
 	}
-	
 	return defaults;
 }
 

--- a/docopt_util.h
+++ b/docopt_util.h
@@ -9,6 +9,7 @@
 #ifndef docopt_docopt_util_h
 #define docopt_docopt_util_h
 
+#include <regex>
 
 #pragma mark -
 #pragma mark General utility
@@ -82,6 +83,17 @@ namespace {
 		for(++iter; iter!=end; ++iter) {
 			ret.append(delim);
 			ret.append(*iter);
+		}
+		return ret;
+	}
+
+	std::vector<std::string> regex_split(std::string const& text, std::regex const& re)
+	{
+		std::vector<std::string> ret;
+		for (auto it = std::sregex_token_iterator(text.begin(), text.end(), re, -1);
+			it != std::sregex_token_iterator();
+			++it) {
+			ret.emplace_back(*it);
 		}
 		return ret;
 	}

--- a/testcases.docopt
+++ b/testcases.docopt
@@ -955,3 +955,21 @@ other options:
 """
 $ prog --baz --egg
 {"--foo": false, "--baz": true, "--bar": false, "--egg": true, "--spam": false}
+
+#
+# Tests new lines in options
+#
+r"""Usage:
+    prog [--foo <foo_>] [--baz <baz_>]
+
+Options:
+  --foo <foo_>
+                          Foo [default: 42]
+  --baz <baz_>
+                          Baz [default: 1]
+"""
+$ prog
+{"--baz": "1", "--foo": "42"}
+
+$ prog --foo 82
+{"--baz": "1", "--foo": "82"}


### PR DESCRIPTION
Hi, 

there is a problem if the option definition spans over multiple lines, then parsing of the [default: x] was not working on Windows - tested on MS Visual Studio 2015.

This is due to the differences in regex's multiline property implementations.

On some platforms - Linux libstd++ the multiline property is off,
on some platforms - msvc2015 the multiline property is on.

It cannot be changed programmatically AFAIK.

I was not able to come up with a regex expression which
would work on Linux and on Windows as well. So I tried to be
smart and replace '\n' by '\f' in the string beforehand.
The regex was easy and worked on Linux and Windows just fine -
up until I tried a longer option definition. Then the msvc2015 
regex failed with 'stack' exception. Hence this change.

It splits the option definition section by a simple regex
which does not use the problematic '$'.

Tell me what you think. All tests are passing.

Regards,
Roman

```
modified:   docopt.cpp
modified:   docopt_util.h
```
