### PR TITLE
Fixes warning in msvc2015.

### DIFF
--- a/docopt.cpp
+++ b/docopt.cpp
@@ -535,7 +535,7 @@ private:
 template <typename T>
 std::vector<T*> flat_filter(Pattern& pattern) {
 	std::vector<Pattern*> flattened = pattern.flat([](Pattern const* p) -> bool {
-		return dynamic_cast<T const*>(p);
+		return dynamic_cast<T const*>(p) != nullptr;
 	});
 	
 	// now, we're guaranteed to have T*'s, so just use static_cast


### PR DESCRIPTION
Hi,

a simple fix for a warning in msvc2015.

warning C4800: 'const docopt::Option *': forcing value to bool 'true' or
'false' (performance warning)

	modified:   docopt.cpp