### PR TITLE
value::asLong will convert from string to long

### DIFF
--- a/docopt_value.h
+++ b/docopt_value.h
@@ -13,7 +13,6 @@
 #include <vector>
 #include <functional> // std::hash
 #include <iosfwd>
-#include <cstdio> // sscanf
 
 namespace docopt {
 
@@ -261,12 +260,9 @@ namespace docopt {
 		// Attempt to convert a string to a long
 		if (kind == Kind::String) {
 			// Doesn't guard against trailing characters,
-			// but doing so (if desired) would be trivial.
-			long ret;
-			if (sscanf(variant.strValue.c_str(), "%ld", &ret) == 1) {
-				return ret;
-			}
-			// else fall through
+			// but doing so (if desired) would be trivial by checking pos.
+			std::size_t pos;
+			return stol(variant.strValue, &pos); // Throws if it can't convert
 		}
 		throwIfNotKind(Kind::Long);
 		return variant.longValue;

--- a/docopt_value.h
+++ b/docopt_value.h
@@ -13,6 +13,7 @@
 #include <vector>
 #include <functional> // std::hash
 #include <iosfwd>
+#include <cstdio> // sscanf
 
 namespace docopt {
 
@@ -257,6 +258,16 @@ namespace docopt {
 	inline
 	long value::asLong() const
 	{
+		// Attempt to convert a string to a long
+		if (kind == Kind::String) {
+			// Doesn't guard against trailing characters,
+			// but doing so (if desired) would be trivial.
+			long ret;
+			if (sscanf(variant.strValue.c_str(), "%ld", &ret) == 1) {
+				return ret;
+			}
+			// else fall through
+		}
 		throwIfNotKind(Kind::Long);
 		return variant.longValue;
 	}

--- a/docopt_value.h
+++ b/docopt_value.h
@@ -259,10 +259,14 @@ namespace docopt {
 	{
 		// Attempt to convert a string to a long
 		if (kind == Kind::String) {
-			// Doesn't guard against trailing characters,
-			// but doing so (if desired) would be trivial by checking pos.
+			const std::string& str = variant.strValue;
 			std::size_t pos;
-			return stol(variant.strValue, &pos); // Throws if it can't convert
+			const long ret = stol(str, &pos); // Throws if it can't convert
+			if (pos != str.length()) {
+				// The string ended in non-digits.
+				throw std::runtime_error( str + " contains non-numeric characters.");
+			}
+			return ret;
 		}
 		throwIfNotKind(Kind::Long);
 		return variant.longValue;


### PR DESCRIPTION
This is less surprising behavior when calling asLong() on an arg expected to be an integer value.

See #27.