### PR TITLE
Revamped CMakeLists.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,28 @@ sudo: false   # Use the new container infrastructure
 matrix:
   include:
     - os: linux
+      env:
+        - COMPILER=g++-5 STDLIB=libc++
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test', 'george-edison55-precise-backports']
+          packages: ["g++-5", "cmake-data", "cmake"]
+
+    - os: linux
       env: 
         - COMPILER=clang++-3.6 STDLIB=libc++
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.6']
-          packages: ["clang-3.6"]
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.6', 'george-edison55-precise-backports']
+          packages: ["clang-3.6", "cmake-data", "cmake"]
 
     - os: linux
       env: 
         - COMPILER=clang++-3.7 STDLIB=libc++
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.7']
-          packages: ["clang-3.7"]
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.7', 'george-edison55-precise-backports']
+          packages: ["clang-3.7", "cmake-data", "cmake"]
 
     - os: osx
       osx_image: xcode6.4
@@ -39,7 +47,7 @@ before_install:
 
   - CMAKE_CXX_FLAGS+=" -Wall"
 
-  - if [[ "${WITH_CPP14}" == "true" ]]; then CMAKE_OPTIONS+=" -DWITH_CPP14=1"; fi
+  - if [[ "${WITH_CPP14}" == "true" ]]; then CMAKE_OPTIONS+=" -DCMAKE_CXX_STANDARD=14"; fi
   - if [[ "${STDLIB}" == "libc++" ]]; then CMAKE_CXX_FLAGS+=" -stdlib=libc++"; fi
 
   - sh ${COMPILER} --version || true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,36 +1,43 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.1)
 
 option(WITH_TESTS           "Build tests."       OFF)
 option(WITH_EXAMPLE         "Build example."     OFF)
 option(WITH_STATIC          "Build static libs." ON)
-option(WITH_CPP11           "Build with C++11."  ON)
-option(WITH_CPP14           "Build with C++14."  OFF)
 
 project(docopt.cpp)
 include_directories("${PROJECT_SOURCE_DIR}")
 
 ########################################################################
+# Compiler properties
+
+# C++ standard
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+if(NOT CMAKE_CXX_STANDARD)
+	set(CMAKE_CXX_STANDARD 11)
+endif()
+
+# Suppression of "unknown pragma" warning on GCC
+if(CMAKE_COMPILER_IS_GNUCXX)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")	# Code uses #pragma mark
+endif()
+
+########################################################################
 # docopt
 
 set(DOCOPT_SRC
-	docopt.cpp
-	docopt.h
-	docopt_private.h
-	docopt_util.h
-	docopt_value.h
-)
+		docopt.cpp
+		docopt.h
+		docopt_private.h
+		docopt_util.h
+		docopt_value.h
+		)
 if(WITH_STATIC)
 	add_library(docopt_s STATIC ${DOCOPT_SRC})
+	target_include_directories(docopt_s PUBLIC "${PROJECT_SOURCE_DIR}")
 endif()
 add_library(docopt SHARED ${DOCOPT_SRC})
-
-if (NOT MSVC)
-    if(WITH_CPP14)
-        add_definitions("-std=c++14")
-    elseif(WITH_CPP11)
-        add_definitions("-std=c++11")
-    endif()
-endif()
+target_include_directories(docopt PUBLIC "${PROJECT_SOURCE_DIR}")
 
 ########################################################################
 # tests
@@ -49,9 +56,9 @@ if (WITH_TESTS)
 	add_executable(run_testcase run_testcase.cpp)
 	target_link_libraries(run_testcase docopt)
 	configure_file(
-		"${PROJECT_SOURCE_DIR}/run_tests.py"
-		"${CMAKE_CURRENT_BINARY_DIR}/run_tests"
-		ESCAPE_QUOTES
+			"${PROJECT_SOURCE_DIR}/run_tests.py"
+			"${CMAKE_CURRENT_BINARY_DIR}/run_tests"
+			ESCAPE_QUOTES
 	)
 	add_test("Testcases docopt" ${TESTPROG})
 endif()
@@ -60,19 +67,19 @@ endif()
 # installation
 
 INSTALL(TARGETS
-	docopt
-	DESTINATION lib)
+		docopt
+		DESTINATION lib)
 if(WITH_STATIC)
 	INSTALL(TARGETS
-		docopt_s
-		DESTINATION lib)
+			docopt_s
+			DESTINATION lib)
 endif()
 INSTALL(FILES
-	docopt.h
-	docopt_private.h
-	docopt_util.h
-	docopt_value.h
-	DESTINATION include/docopt)
+		docopt.h
+		docopt_private.h
+		docopt_util.h
+		docopt_value.h
+		DESTINATION include/docopt)
 SET(CPACK_PACKAGE_NAME "docopt")
 SET(CPACK_DEBIAN_PACKAGE_DEPENDS "")
 SET(CPACK_RPM_PACKAGE_REQUIRES "")


### PR DESCRIPTION
Bumped CMake version to 3.1
Removed WITH_CPP** options, in favor of -DCMAKE_CXX_STANDARD=11
Added public includes to both dynamic and static targets, enabling CMake-idiomatic way to link these libraries with link_library and without include_directory
Fixed "#pragma mark" warnings on GCC