### PR TITLE
Don't use C++11/14 flags when compiling with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,10 +24,12 @@ if(WITH_STATIC)
 endif()
 add_library(docopt SHARED ${DOCOPT_SRC})
 
-if(WITH_CPP14)
-    add_definitions("-std=c++14")
-elseif(WITH_CPP11)
-    add_definitions("-std=c++11")
+if (NOT MSVC)
+    if(WITH_CPP14)
+        add_definitions("-std=c++14")
+    elseif(WITH_CPP11)
+        add_definitions("-std=c++11")
+    endif()
 endif()
 
 ########################################################################


### PR DESCRIPTION
When using MSVC, shouldn't set the -std=c++11 or -std=c++14 flags. Not sure if this is the best fix but it works!