### PR TITLE
Support GCC 4.8, using Boost.Regex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,16 @@ matrix:
         apt:
           sources: ['ubuntu-toolchain-r-test', 'george-edison55-precise-backports']
           packages: ["g++-5", "cmake-data", "cmake"]
+    - os: linux
+      env:
+        - COMPILER=g++-4.8 USE_BOOST_REGEX=ON
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test', 'george-edison55-precise-backports', 'boost-latest']
+          packages: ["g++-4.8", "cmake-data", "cmake", "libboost-regex1.55-dev"]
 
     - os: linux
-      env: 
+      env:
         - COMPILER=clang++-3.6 STDLIB=libc++
       addons:
         apt:
@@ -20,7 +27,7 @@ matrix:
           packages: ["clang-3.6", "cmake-data", "cmake"]
 
     - os: linux
-      env: 
+      env:
         - COMPILER=clang++-3.7 STDLIB=libc++
       addons:
         apt:
@@ -29,13 +36,13 @@ matrix:
 
     - os: osx
       osx_image: xcode6.4
-      env: 
+      env:
         - COMPILER=clang++ V='Apple LLVM 6.4'
         - COMPILER=clang++ V='Apple LLVM 6.4' WITH_CPP14=true
 
     - os: osx
       osx_image: xcode7
-      env: 
+      env:
         - COMPILER=clang++ V='Apple LLVM 7.0'
         - COMPILER=clang++ V='Apple LLVM 7.0' WITH_CPP14=true
 
@@ -48,6 +55,12 @@ before_install:
   - CMAKE_CXX_FLAGS+=" -Wall"
 
   - if [[ "${WITH_CPP14}" == "true" ]]; then CMAKE_OPTIONS+=" -DCMAKE_CXX_STANDARD=14"; fi
+  - |
+    if [[ "${USE_BOOST_REGEX}" == "ON" ]]; then
+        CMAKE_OPTIONS+=" -DUSE_BOOST_REGEX=ON"
+        CMAKE_OPTIONS+=" -DBoost_REGEX_LIBRARY_DEBUG=/usr/lib/x86_64-linux-gnu/libboost_regex.so.1.55.0"
+        CMAKE_OPTIONS+=" -DBoost_REGEX_LIBRARY_RELEASE=/usr/lib/x86_64-linux-gnu/libboost_regex.so.1.55.0"
+    fi
   - if [[ "${STDLIB}" == "libc++" ]]; then CMAKE_CXX_FLAGS+=" -stdlib=libc++"; fi
 
   - sh ${COMPILER} --version || true
@@ -58,6 +71,6 @@ before_script:
   - cd build
   - cmake -DCMAKE_CXX_COMPILER=${COMPILER} -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS} -DWITH_TESTS=1 -DWITH_EXAMPLE=1 ${CMAKE_OPTIONS} ..
 
-script: 
+script:
   - cmake --build .
   - python run_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ matrix:
 before_install:
   - |
     if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
-      brew install cmake
+      brew rm --force cmake && brew install cmake
     fi
 
   - CMAKE_CXX_FLAGS+=" -Wall"

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ before_install:
     fi
   - if [[ "${STDLIB}" == "libc++" ]]; then CMAKE_CXX_FLAGS+=" -stdlib=libc++"; fi
 
-  - sh ${COMPILER} --version || true
+  - ${COMPILER} --version
 
 before_script:
   - rm -rf build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ include(GNUInstallDirs)
 #============================================================================
 option(WITH_TESTS "Build tests." OFF)
 option(WITH_EXAMPLE "Build example." OFF)
+option(USE_BOOST_REGEX "Replace std::regex with Boost.Regex" OFF)
 
 #============================================================================
 # Internal compiler options
@@ -50,6 +51,19 @@ target_include_directories(docopt_s PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DI
 if(NOT MSVC)
 	set_target_properties(docopt PROPERTIES OUTPUT_NAME docopt)
 	set_target_properties(docopt_s PROPERTIES OUTPUT_NAME docopt)
+endif()
+
+if(USE_BOOST_REGEX)
+	add_definitions("-DDOCTOPT_USE_BOOST_REGEX")
+	# This is needed on Linux, where linking a static library into docopt.so
+	# fails because boost static libs are not compiled with -fPIC
+	set(Boost_USE_STATIC_LIBS OFF)
+    find_package(Boost 1.53 REQUIRED COMPONENTS regex)
+    include_directories(${Boost_INCLUDE_DIRS})
+    target_link_libraries(docopt ${Boost_LIBRARIES})
+	if(WITH_STATIC)
+		target_link_libraries(docopt_s ${Boost_LIBRARIES})
+	endif()
 endif()
 
 #============================================================================

--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,8 @@ to work with docopt:
 
 GCC-4.8 can work, but the std::regex module needs to be replaced with ``Boost.Regex``.
 In that case, you will need to define ``DOCTOPT_USE_BOOST_REGEX`` when compiling
-docopt, and link your code with the appropriated Boost libraries.
+docopt, and link your code with the appropriated Boost libraries. A relativley
+recent version of Boost is needed: 1.55 works, but 1.46 does not for example.
 
 This port is licensed under the MIT license, just like the original module.
 However, we are also dual-licensing this code under the Boost License, version 1.0,

--- a/README.rst
+++ b/README.rst
@@ -42,8 +42,8 @@ and instead can write only the help message--*the way you want it*.
 
     int main(int argc, const char** argv)
     {
-        std::map<std::string, docopt::value> args 
-            = docopt::docopt(USAGE, 
+        std::map<std::string, docopt::value> args
+            = docopt::docopt(USAGE,
                              { argv + 1, argv + argc },
                              true,               // show help if requested
                              "Naval Fate 2.0");  // version string
@@ -78,7 +78,9 @@ to work with docopt:
 - GCC 4.9
 - Visual C++ 2015 RC
 
-Note that GCC-4.8 will not work due to its missing the ``regex`` module. 
+GCC-4.8 can work, but the std::regex module needs to be replaced with ``Boost.Regex``.
+In that case, you will need to define ``DOCTOPT_USE_BOOST_REGEX`` when compiling
+docopt, and link your code with the appropriated Boost libraries.
 
 This port is licensed under the MIT license, just like the original module.
 However, we are also dual-licensing this code under the Boost License, version 1.0,
@@ -92,8 +94,8 @@ The differences from the Python port are:
 * a ``docopt::value`` type to hold the various value types that can be parsed.
   We considered using boost::variant, but it seems better to have no external
   dependencies (beyond a good STL).
-* because C++ is statically-typed and Python is not, we had to make some 
-  changes to the interfaces of the internal parse tree types. 
+* because C++ is statically-typed and Python is not, we had to make some
+  changes to the interfaces of the internal parse tree types.
 * because ``std::regex`` does not have an equivalent to Python's regex.split,
   some of the regex's had to be restructured and additional loops used.
 
@@ -126,7 +128,7 @@ API
 - ``argv`` is a vector of strings representing the args passed. Although
   main usually takes a ``(int argc, const char** argv)`` pair, you can
   pass the value ``{argv+1, argv+argc}`` to generate the vector automatically.
-  (Note we skip the argv[0] argument!) Alternatively you can supply a list of 
+  (Note we skip the argv[0] argument!) Alternatively you can supply a list of
   strings like ``{ "--verbose", "-o", "hai.txt" }``.
 
 - ``help``, by default ``true``, specifies whether the parser should
@@ -155,8 +157,8 @@ API
   compatibility with POSIX, or if you want to dispatch your arguments
   to other programs.
 
-The **return** value is a ``map<string, docopt::value>`` with options, 
-arguments and commands as keys, spelled exactly like in your help message.  
+The **return** value is a ``map<string, docopt::value>`` with options,
+arguments and commands as keys, spelled exactly like in your help message.
 Long versions of options are given priority. For example, if you invoke the
 top example as::
 
@@ -372,7 +374,7 @@ We have an extensive list of `examples
 every aspect of functionality of **docopt**.  Try them out, read the
 source if in doubt.
 
-There are also very intersting applications and ideas at that page. 
+There are also very intersting applications and ideas at that page.
 Check out the sister project for more information!
 
 Subparsers, multi-level help and *huge* applications (like git)
@@ -397,7 +399,7 @@ a C++ test case runner (run_testcase.cpp)::
 
   $ clang++ --std=c++11 --stdlib=libc++ docopt.cpp run_testcase.cpp -o run_testcase
   $ python run_tests.py
-  PASS (175) 
+  PASS (175)
 
 You can also compile the example shown at the start (included as example.cpp)::
 
@@ -424,10 +426,10 @@ You can also compile the example shown at the start (included as example.cpp)::
 Development
 ---------------------------------------------------
 
-Comments and suggestions are *very* welcome! If you find issues, please 
+Comments and suggestions are *very* welcome! If you find issues, please
 file them and help improve our code!
 
-Please note, however, that we have tried to stay true to the original 
+Please note, however, that we have tried to stay true to the original
 Python code. If you have any major patches, structural changes, or new features,
 we might want to first negotiate these changes into the Python code first.
 However, bring it up! Let's hear it!
@@ -439,4 +441,3 @@ Changelog
 first release with stable API will be 1.0.0 (soon).
 
 - 0.6.1 The initial C++ port of docopt.py
-

--- a/docopt.cpp
+++ b/docopt.cpp
@@ -17,7 +17,6 @@
 #include <unordered_map>
 #include <map>
 #include <string>
-#include <regex>
 #include <iostream>
 #include <cassert>
 #include <cstddef>

--- a/docopt_private.h
+++ b/docopt_private.h
@@ -12,18 +12,33 @@
 #include <vector>
 #include <memory>
 #include <unordered_set>
-#include <regex>
 #include <assert.h>
+
+// Workaround GCC 4.8 not having std::regex
+#if DOCTOPT_USE_BOOST_REGEX
+#include <boost/regex.hpp>
+namespace std {
+	using boost::regex;
+   	using boost::sregex_iterator;
+   	using boost::smatch;
+   	using boost::regex_search;
+   	namespace regex_constants {
+		using boost::regex_constants::match_not_null;
+   	}
+}
+#else
+#include <regex>
+#endif
 
 #include "docopt_value.h"
 
 namespace docopt {
-	
+
 	class Pattern;
 	class LeafPattern;
-	
+
 	using PatternList = std::vector<std::shared_ptr<Pattern>>;
-	
+
 	// Utility to use Pattern types in std hash-containers
 	struct PatternHasher {
 		template <typename P>
@@ -39,7 +54,7 @@ namespace docopt {
 			return pattern.hash();
 		}
 	};
-	
+
 	// Utility to use 'hash' as the equality operator as well in std containers
 	struct PatternPointerEquality {
 		template <typename P1, typename P2>
@@ -51,34 +66,34 @@ namespace docopt {
 			return p1->hash()==p2->hash();
 		}
 	};
-	
+
 	// A hash-set that uniques by hash value
 	using UniquePatternSet = std::unordered_set<std::shared_ptr<Pattern>, PatternHasher, PatternPointerEquality>;
 
-	
+
 	class Pattern {
 	public:
 		// flatten out children, stopping descent when the given filter returns 'true'
 		virtual std::vector<Pattern*> flat(bool (*filter)(Pattern const*)) = 0;
-		
+
 		// flatten out all children into a list of LeafPattern objects
 		virtual void collect_leaves(std::vector<LeafPattern*>&) = 0;
-		
+
 		// flatten out all children into a list of LeafPattern objects
 		std::vector<LeafPattern*> leaves();
-		
+
 		// Attempt to find something in 'left' that matches this pattern's spec, and if so, move it to 'collected'
 		virtual bool match(PatternList& left, std::vector<std::shared_ptr<LeafPattern>>& collected) const = 0;
-		
+
 		virtual std::string const& name() const = 0;
-		
+
 		virtual bool hasValue() const { return false; }
-		
+
 		virtual size_t hash() const = 0;
 
 		virtual ~Pattern() = default;
 	};
-	
+
 	class LeafPattern
 	: public Pattern {
 	public:
@@ -86,27 +101,27 @@ namespace docopt {
 		: fName(std::move(name)),
 		  fValue(std::move(v))
 		{}
-		
+
 		virtual std::vector<Pattern*> flat(bool (*filter)(Pattern const*)) override {
 			if (filter(this)) {
 				return { this };
 			}
 			return {};
 		}
-		
+
 		virtual void collect_leaves(std::vector<LeafPattern*>& lst) override final {
 			lst.push_back(this);
 		}
-		
+
 		virtual bool match(PatternList& left, std::vector<std::shared_ptr<LeafPattern>>& collected) const override;
-		
+
 		virtual bool hasValue() const override { return static_cast<bool>(fValue); }
-		
+
 		value const& getValue() const { return fValue; }
 		void setValue(value&& v) { fValue = std::move(v); }
-				
+
 		virtual std::string const& name() const override { return fName; }
-		
+
 		virtual size_t hash() const override {
 			size_t seed = typeid(*this).hash_code();
 			hash_combine(seed, fName);
@@ -116,39 +131,39 @@ namespace docopt {
 
 	protected:
 		virtual std::pair<size_t, std::shared_ptr<LeafPattern>> single_match(PatternList const&) const = 0;
-		
+
 	private:
 		std::string fName;
 		value fValue;
 	};
-	
+
 	class BranchPattern
 	: public Pattern {
 	public:
 		BranchPattern(PatternList children = {})
 		: fChildren(std::move(children))
 		{}
-		
+
 		Pattern& fix() {
 			UniquePatternSet patterns;
 			fix_identities(patterns);
 			fix_repeating_arguments();
 			return *this;
 		}
-		
+
 		virtual std::string const& name() const override {
 			throw std::runtime_error("Logic error: name() shouldnt be called on a BranchPattern");
 		}
-		
+
 		virtual value const& getValue() const {
 			throw std::runtime_error("Logic error: name() shouldnt be called on a BranchPattern");
 		}
-		
+
 		virtual std::vector<Pattern*> flat(bool (*filter)(Pattern const*)) override {
 			if (filter(this)) {
 				return {this};
 			}
-			
+
 			std::vector<Pattern*> ret;
 			for(auto& child : fChildren) {
 				auto sublist = child->flat(filter);
@@ -156,26 +171,26 @@ namespace docopt {
 			}
 			return ret;
 		}
-		
+
 		virtual void collect_leaves(std::vector<LeafPattern*>& lst) override final {
 			for(auto& child : fChildren) {
 				child->collect_leaves(lst);
 			}
 		}
-		
+
 		void setChildren(PatternList children) {
 			fChildren = std::move(children);
 		}
-		
+
 		PatternList const& children() const { return fChildren; }
-		
+
 		virtual void fix_identities(UniquePatternSet& patterns) {
 			for(auto& child : fChildren) {
 				// this will fix up all its children, if needed
 				if (auto bp = dynamic_cast<BranchPattern*>(child.get())) {
 					bp->fix_identities(patterns);
 				}
-				
+
 				// then we try to add it to the list
 				auto inserted = patterns.insert(child);
 				if (!inserted.second) {
@@ -184,7 +199,7 @@ namespace docopt {
 				}
 			}
 		}
-		
+
 		virtual size_t hash() const override {
 			size_t seed = typeid(*this).hash_code();
 			hash_combine(seed, fChildren.size());
@@ -195,36 +210,36 @@ namespace docopt {
 		}
 	private:
 		void fix_repeating_arguments();
-		
+
 	protected:
 		PatternList fChildren;
 	};
-	
+
 	class Argument
 	: public LeafPattern {
 	public:
 		using LeafPattern::LeafPattern;
-		
+
 	protected:
 		virtual std::pair<size_t, std::shared_ptr<LeafPattern>> single_match(PatternList const& left) const override;
 	};
-	
+
 	class Command : public Argument {
 	public:
 		Command(std::string name, value v = value{false})
 		: Argument(std::move(name), std::move(v))
 		{}
-		
+
 	protected:
 		virtual std::pair<size_t, std::shared_ptr<LeafPattern>> single_match(PatternList const& left) const override;
 	};
-	
+
 	class Option final
 	: public LeafPattern
 	{
 	public:
 		static Option parse(std::string const& option_description);
-		
+
 		Option(std::string shortOption,
 		       std::string longOption,
 		       int argcount = 0,
@@ -241,18 +256,18 @@ namespace docopt {
 				setValue(value{});
 			}
 		}
-		
+
 		Option(Option const&) = default;
 		Option(Option&&) = default;
 		Option& operator=(Option const&) = default;
 		Option& operator=(Option&&) = default;
-		
+
 		using LeafPattern::setValue;
-		
+
 		std::string const& longOption() const { return fLongOption; }
 		std::string const& shortOption() const { return fShortOption; }
 		int argCount() const { return fArgcount; }
-		
+
 		virtual size_t hash() const override {
 			size_t seed = LeafPattern::hash();
 			hash_combine(seed, fShortOption);
@@ -260,7 +275,7 @@ namespace docopt {
 			hash_combine(seed, fArgcount);
 			return seed;
 		}
-		
+
 	protected:
 		virtual std::pair<size_t, std::shared_ptr<LeafPattern>> single_match(PatternList const& left) const override;
 
@@ -273,14 +288,14 @@ namespace docopt {
 	class Required : public BranchPattern {
 	public:
 		using BranchPattern::BranchPattern;
-		
+
 		bool match(PatternList& left, std::vector<std::shared_ptr<LeafPattern>>& collected) const override;
 	};
 
 	class Optional : public BranchPattern {
 	public:
 		using BranchPattern::BranchPattern;
-		
+
 		bool match(PatternList& left, std::vector<std::shared_ptr<LeafPattern>>& collected) const override {
 			for(auto const& pattern : fChildren) {
 				pattern->match(left, collected);
@@ -296,14 +311,14 @@ namespace docopt {
 	class OneOrMore : public BranchPattern {
 	public:
 		using BranchPattern::BranchPattern;
-		
+
 		bool match(PatternList& left, std::vector<std::shared_ptr<LeafPattern>>& collected) const override;
 	};
 
 	class Either : public BranchPattern {
 	public:
 		using BranchPattern::BranchPattern;
-		
+
 		bool match(PatternList& left, std::vector<std::shared_ptr<LeafPattern>>& collected) const override;
 	};
 

--- a/docopt_util.h
+++ b/docopt_util.h
@@ -9,6 +9,15 @@
 #ifndef docopt_docopt_util_h
 #define docopt_docopt_util_h
 
+#if DOCTOPT_USE_BOOST_REGEX
+#include <boost/regex.hpp>
+namespace std {
+    using boost::regex;
+    using boost::sregex_token_iterator;
+}
+#else
+#include <regex>
+#endif
 
 #pragma mark -
 #pragma mark General utility
@@ -21,7 +30,7 @@ namespace {
 		return std::equal(prefix.begin(), prefix.end(),
 				  str.begin());
 	}
-	
+
 	std::string trim(std::string&& str,
 			 const std::string& whitespace = " \t\n")
 	{
@@ -29,38 +38,38 @@ namespace {
 		if (strEnd==std::string::npos)
 			return {}; // no content
 		str.erase(strEnd+1);
-		
+
 		const auto strBegin = str.find_first_not_of(whitespace);
 		str.erase(0, strBegin);
-		
+
 		return std::move(str);
 	}
-	
+
 	std::vector<std::string> split(std::string const& str, size_t pos = 0)
 	{
 		const char* const anySpace = " \t\r\n\v\f";
-		
+
 		std::vector<std::string> ret;
 		while (pos != std::string::npos) {
 			auto start = str.find_first_not_of(anySpace, pos);
 			if (start == std::string::npos) break;
-			
+
 			auto end = str.find_first_of(anySpace, start);
 			auto size = end==std::string::npos ? end : end-start;
 			ret.emplace_back(str.substr(start, size));
-			
+
 			pos = end;
 		}
-		
+
 		return ret;
 	}
-	
+
 	std::tuple<std::string, std::string, std::string> partition(std::string str, std::string const& point)
 	{
 		std::tuple<std::string, std::string, std::string> ret;
-		
+
 		auto i = str.find(point);
-		
+
 		if (i == std::string::npos) {
 			// no match: string goes in 0th spot only
 		} else {
@@ -69,19 +78,30 @@ namespace {
 			str.resize(i);
 		}
 		std::get<0>(ret) = std::move(str);
-		
+
 		return ret;
 	}
-	
+
 	template <typename I>
 	std::string join(I iter, I end, std::string const& delim) {
 		if (iter==end)
 			return {};
-		
+
 		std::string ret = *iter;
 		for(++iter; iter!=end; ++iter) {
 			ret.append(delim);
 			ret.append(*iter);
+		}
+		return ret;
+	}
+
+	std::vector<std::string> regex_split(std::string const& text, std::regex const& re)
+	{
+		std::vector<std::string> ret;
+		for (auto it = std::sregex_token_iterator(text.begin(), text.end(), re, -1);
+			it != std::sregex_token_iterator();
+			++it) {
+			ret.emplace_back(*it);
 		}
 		return ret;
 	}

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python2
 
 import re
+import sys
 import json
 import subprocess
 
@@ -10,7 +11,7 @@ def parse_test(raw):
 	raw = re.compile('#.*$', re.M).sub('', raw).strip()
 	if raw.startswith('"""'):
 		raw = raw[3:]
-	
+
 	for fixture in raw.split('r"""'):
 		name = ''
 		doc, _, body = fixture.partition('"""')
@@ -20,7 +21,7 @@ def parse_test(raw):
 			expect = json.loads(expect)
 			prog, _, argv = argv.strip().partition(' ')
 			cases.append((prog, argv, expect))
-		
+
 		yield name, doc, cases
 
 failures = 0
@@ -29,10 +30,10 @@ passes = 0
 tests = open('${TESTCASES}','r').read()
 for _, doc, cases in parse_test(tests):
 	if not cases: continue
-	
+
 	for prog, argv, expect in cases:
 		args = [ x for x in argv.split() if x ]
-		
+
 		expect_error = not isinstance(expect, dict)
 
 		error = None
@@ -66,6 +67,6 @@ for _, doc, cases in parse_test(tests):
 
 if failures:
 	print "%d failures" % failures
+	sys.exit(1)
 else:
 	print "PASS (%d)" % passes
-


### PR DESCRIPTION
I got one failure on my machine: 

```
$ ./run_tests
========================================
UsAgE: prog [options]

OpTiOnS: --path=<files>  Path to files
                [dEfAuLt: /root]


::::::::::::::::::::
prog
--------------------
{ "--path": null }

 ** JSON does not match expected: {u'--path': u'/root'}
1 failures
```

Also, I checked that the code still compiles normally using clang.
I can try to add GCC 4.8 to travis, but this will make it fail.

Fixes #42.