### PR TITLE
Empty lines do not break options sections.

### DIFF
--- a/docopt.cpp
+++ b/docopt.cpp
@@ -168,8 +168,8 @@ static std::vector<std::string> parse_section(std::string const& name, std::stri
 	std::regex const re_section_pattern {
 		"(?:^|\\n)"  // anchored at a linebreak (or start of string)
 		"("
-		   "[^\\n]*" + name + "[^\\n]*(?=\\n?)" // a line that contains the name
-		   "(?:\\n[ \\t].*?(?=\\n|$))*"         // followed by any number of lines that are indented
+		   "[^\\n]*" + name + "[^\\n]*(?=\\n?)" // a line that contains the section name
+		   "(?:\\n+[ \\t].*?(?=\\n|$))*"        // followed by any number of indented or empty lines
 		")",
 		std::regex::icase
 	};

--- a/testcases.docopt
+++ b/testcases.docopt
@@ -955,3 +955,21 @@ other options:
 """
 $ prog --baz --egg
 {"--foo": false, "--baz": true, "--bar": false, "--egg": true, "--spam": false}
+
+
+# An empty line must not break an options section.
+r"""
+Usage: prog [options]
+
+Options:
+  --before-empty-lines  An option before empty lines.
+
+
+  --after-empty-lines   An option after empty lines.
+"""
+
+$ prog --before-empty-lines
+{"--before-empty-lines": true, "--after-empty-lines": false}
+
+$ prog --after-empty-line
+{"--before-empty-lines": false, "--after-empty-lines": true}


### PR DESCRIPTION
There are several reasons why an options section can be split by an
empty line, among them are:
- logically grouping;
- aesthetic reasons.

Such style is used, for example, in `man` program.

An example:

    Options:
      --before-empty-lines  An option before empty lines.

      --after-empty-lines   An option after empty lines.