### PR TITLE
.gitignore is updated with CMake and Cygwin specific files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Compiled Dynamic libraries
 *.so
 *.dylib
+*.dll
 
 # Compiled Static libraries
 *.lai
@@ -16,3 +17,16 @@
 example
 naval_fate
 run_testcase
+run_testcase.exe
+
+# CMake temporary files
+CMakeCache.txt
+CMakeFiles
+CPackConfig.cmake
+CPackSourceConfig.cmake
+Makefile
+cmake_install.cmake
+docopt-config-version.cmake
+
+# Files configured by CMake
+run_tests


### PR DESCRIPTION
Following file types are added:
- Files generated by CMake:
  - internal CMake files; and
  - `run_tests` file, as a result of run_tests.py configuration.
- Cygwin specific files.