### PR TITLE
An option description can be located after a new line

### DIFF
--- a/docopt_private.h
+++ b/docopt_private.h
@@ -530,7 +530,7 @@ namespace docopt {
 			options_end = option_description.begin() + static_cast<std::ptrdiff_t>(double_space);
 		}
 
-		static const std::regex pattern {"(-{1,2})?(.*?)([,= ]|$)"};
+		static const std::regex pattern {"(-{1,2})?(.*?)([,= \n]|$)"};
 		for(std::sregex_iterator i {option_description.begin(), options_end, pattern, std::regex_constants::match_not_null},
 			   e{};
 			i != e;

--- a/testcases.docopt
+++ b/testcases.docopt
@@ -955,3 +955,23 @@ other options:
 """
 $ prog --baz --egg
 {"--foo": false, "--baz": true, "--bar": false, "--egg": true, "--spam": false}
+
+
+# An option description can be located after a new line.
+r"""usage: prog [options]
+
+options:
+  --foo, -f
+      Description on a new line.
+  --bar, -b
+      Description on a new line.
+"""
+
+$ prog --foo
+{"--foo": true, "--bar": false}
+$ prog --f
+{"--foo": true, "--bar": false}
+$ prog --bar
+{"--foo": false, "--bar": true}
+$ prog -b
+{"--foo": false, "--bar": true}


### PR DESCRIPTION
Sometimes if an option is too long, it looks better when its description starts on a new line.

Such behaviour is supported (though it is not documented) by the original [docopt](https://github.com/docopt/docopt). A [commit](https://github.com/docopt/docopt/pull/342) with corresponding test is requested to be pulled.