### PR TITLE
Support Xcode by not using CMake object libraries when using Xcode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,11 +39,20 @@ set(docopt_HEADERS
 #============================================================================
 # Compile targets
 #============================================================================
-add_library(docopt_o OBJECT ${docopt_SOURCES} ${docopt_HEADERS})
-set_target_properties(docopt_o PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+if(XCODE)
+    # Xcode does not support libraries with only object files as sources.
+    # See https://cmake.org/cmake/help/v3.0/command/add_library.html?highlight=add_library
+    add_library(docopt SHARED ${docopt_SOURCES} ${docopt_HEADERS})
+    add_library(docopt_s STATIC ${docopt_SOURCES} ${docopt_HEADERS})
+else()
+    # If not using Xcode, we will create an intermediate object target to avoid
+    # compiling the source code twice.
+    add_library(docopt_o OBJECT ${docopt_SOURCES} ${docopt_HEADERS})
+    set_target_properties(docopt_o PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 
-add_library(docopt SHARED $<TARGET_OBJECTS:docopt_o>)
-add_library(docopt_s STATIC $<TARGET_OBJECTS:docopt_o>)
+    add_library(docopt SHARED $<TARGET_OBJECTS:docopt_o>)
+    add_library(docopt_s STATIC $<TARGET_OBJECTS:docopt_o>)
+endif()
 
 target_include_directories(docopt PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}> $<INSTALL_INTERFACE:include/docopt>)
 target_include_directories(docopt_s PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}> $<INSTALL_INTERFACE:include/docopt>)


### PR DESCRIPTION
CMake allows specifying an object file as a source file for a library target, but
Xcode (using the CMake Xcode generator) does not allow library targets whose source files are *all* object
files; there needs to be at least one real source file. This PR gets around
this issue by not using object library targets with Xcode. The object library is still used with other CMake generators so that the code isn't compiled twice unnecessarily.

@GamePad64 may be interested in reviewing this, since he added the object library target.