### PR TITLE
Export symbols on windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,9 @@ endif()
 target_include_directories(docopt PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}> $<INSTALL_INTERFACE:include/docopt>)
 target_include_directories(docopt_s PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}> $<INSTALL_INTERFACE:include/docopt>)
 
+# To control the exporting of symbols (on Windows).
+set_target_properties(docopt PROPERTIES DEFINE_SYMBOL DOCOPT_EXPORTS)
+
 if(NOT MSVC)
 	set_target_properties(docopt PROPERTIES OUTPUT_NAME docopt)
 	set_target_properties(docopt_s PROPERTIES OUTPUT_NAME docopt)

--- a/docopt.h
+++ b/docopt.h
@@ -16,9 +16,22 @@
 #include <string>
 
 #ifdef DOCOPT_HEADER_ONLY
-#define DOCOPT_INLINE inline
+    #define DOCOPT_INLINE inline
+    #define DOCOPTAPI
 #else 
-#define DOCOPT_INLINE
+    #define DOCOPT_INLINE
+
+    // On Windows, export certain symbols so they are available
+    // to users of docopt.dll (shared library).
+    #ifdef WIN32
+        #ifdef DOCOPT_EXPORTS
+            #define DOCOPTAPI __declspec(dllexport)
+        #else
+            #define DOCOPTAPI __declspec(dllimport)
+        #endif
+    #else
+        #define DOCOPTAPI
+    #endif
 #endif
 
 namespace docopt {
@@ -48,7 +61,7 @@ namespace docopt {
 	/// @throws DocoptExitHelp if 'help' is true and the user has passed the '--help' argument
 	/// @throws DocoptExitVersion if 'version' is true and the user has passed the '--version' argument
 	/// @throws DocoptArgumentError if the user's argv did not match the usage patterns
-	std::map<std::string, value> docopt_parse(std::string const& doc,
+	std::map<std::string, value> DOCOPTAPI docopt_parse(std::string const& doc,
 					    std::vector<std::string> const& argv,
 					    bool help = true,
 					    bool version = true,
@@ -61,7 +74,7 @@ namespace docopt {
 	///  * DocoptExitHelp - print usage string and terminate (with exit code 0)
 	///  * DocoptExitVersion - print version and terminate (with exit code 0)
 	///  * DocoptArgumentError - print error and usage string and terminate (with exit code -1)
-	std::map<std::string, value> docopt(std::string const& doc,
+	std::map<std::string, value> DOCOPTAPI docopt(std::string const& doc,
 					    std::vector<std::string> const& argv,
 					    bool help = true,
 					    std::string const& version = {},
@@ -69,7 +82,7 @@ namespace docopt {
 }
 
 #ifdef DOCOPT_HEADER_ONLY
-#include "docopt.cpp"
+    #include "docopt.cpp"
 #endif
 
 #endif /* defined(docopt__docopt_h_) */


### PR DESCRIPTION
This PR fixes the issue raised by @klshrinidhi in #57. Basically, MSVC should have produced a `docopt.lib` file but it did not because no symbols were exported. See [here](http://stackoverflow.com/questions/3950509/build-succeeded-but-no-lib-file-gets-created).

So, this PR causes two functions to be exported (available for use by users of `docopt.dll`) using a set of macros that are commonly used to handle this scenario; see [here](http://stackoverflow.com/questions/225432/export-all-symbols-when-creating-a-dll) and [here](https://github.com/opensim-org/opensim-core/blob/master/OpenSim/Common/osimCommonDLL.h#L37).

As a result, a `docopt.lib` file is now produced, thus allowing Windows/MSVC users to make use of the `docopt.dll` shared library.