### PR TITLE
Fix support for building static library with Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,14 +39,18 @@ set(docopt_HEADERS
 #============================================================================
 # Compile targets
 #============================================================================
-if(XCODE)
+if(MSVC OR XCODE)
+	# MSVC requires __declspec() attributes, which are achieved via the 
+	# DOCOPT_DLL and DOCOPT_EXPORTS macros below. Since those macros are only
+	# defined when building a shared library, we must build the shared and
+	# static libraries completely separately.
     # Xcode does not support libraries with only object files as sources.
     # See https://cmake.org/cmake/help/v3.0/command/add_library.html?highlight=add_library
     add_library(docopt SHARED ${docopt_SOURCES} ${docopt_HEADERS})
     add_library(docopt_s STATIC ${docopt_SOURCES} ${docopt_HEADERS})
 else()
-    # If not using Xcode, we will create an intermediate object target to avoid
-    # compiling the source code twice.
+    # If not using MSVC or Xcode, we will create an intermediate object target
+    # to avoid compiling the source code twice.
     add_library(docopt_o OBJECT ${docopt_SOURCES} ${docopt_HEADERS})
     set_target_properties(docopt_o PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 
@@ -56,6 +60,15 @@ endif()
 
 target_include_directories(docopt PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}> $<INSTALL_INTERFACE:include/docopt>)
 target_include_directories(docopt_s PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}> $<INSTALL_INTERFACE:include/docopt>)
+
+if(MSVC)
+    # DOCOPT_DLL: Must be specified when building *and* when using the DLL.
+    #             That's what the "PUBLIC" means.
+    # DOCOPT_EXPORTS: Must use __declspec(dllexport) when building the DLL.
+    #                 "PRIVATE" means it's only defined when building the DLL.
+    target_compile_definitions(docopt PUBLIC  DOCOPT_DLL
+                                      PRIVATE DOCOPT_EXPORTS)
+endif()
 
 if(NOT MSVC)
 	set_target_properties(docopt PROPERTIES OUTPUT_NAME docopt)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,10 +40,10 @@ set(docopt_HEADERS
 # Compile targets
 #============================================================================
 if(MSVC OR XCODE)
-	# MSVC requires __declspec() attributes, which are achieved via the 
-	# DOCOPT_DLL and DOCOPT_EXPORTS macros below. Since those macros are only
-	# defined when building a shared library, we must build the shared and
-	# static libraries completely separately.
+    # MSVC requires __declspec() attributes, which are achieved via the 
+    # DOCOPT_DLL and DOCOPT_EXPORTS macros below. Since those macros are only
+    # defined when building a shared library, we must build the shared and
+    # static libraries completely separately.
     # Xcode does not support libraries with only object files as sources.
     # See https://cmake.org/cmake/help/v3.0/command/add_library.html?highlight=add_library
     add_library(docopt SHARED ${docopt_SOURCES} ${docopt_HEADERS})

--- a/docopt.h
+++ b/docopt.h
@@ -67,7 +67,7 @@ namespace docopt {
 	/// @throws DocoptExitHelp if 'help' is true and the user has passed the '--help' argument
 	/// @throws DocoptExitVersion if 'version' is true and the user has passed the '--version' argument
 	/// @throws DocoptArgumentError if the user's argv did not match the usage patterns
-    std::map<std::string, value> DOCOPT_API docopt_parse(std::string const& doc,
+	std::map<std::string, value> DOCOPT_API docopt_parse(std::string const& doc,
 					    std::vector<std::string> const& argv,
 					    bool help = true,
 					    bool version = true,

--- a/docopt.h
+++ b/docopt.h
@@ -16,9 +16,28 @@
 #include <string>
 
 #ifdef DOCOPT_HEADER_ONLY
-#define DOCOPT_INLINE inline
+    #define DOCOPT_INLINE inline
+    #define DOCOPT_API
 #else 
-#define DOCOPT_INLINE
+    #define DOCOPT_INLINE
+
+    // With Microsoft Visual Studio, export certain symbols so they 
+    // are available to users of docopt.dll (shared library). The DOCOPT_DLL
+    // macro should be defined if building a DLL (with Visual Studio),
+    // and by clients using the DLL. The CMakeLists.txt and the
+    // docopt-config.cmake it generates handle this.
+    #ifdef DOCOPT_DLL
+        // Whoever is *building* the DLL should define DOCOPT_EXPORTS.
+        // The CMakeLists.txt that comes with docopt does this.
+        // Clients of docopt.dll should NOT define DOCOPT_EXPORTS.
+        #ifdef DOCOPT_EXPORTS
+            #define DOCOPT_API __declspec(dllexport)
+        #else
+            #define DOCOPT_API __declspec(dllimport)
+        #endif
+    #else
+        #define DOCOPT_API
+    #endif
 #endif
 
 namespace docopt {
@@ -48,7 +67,7 @@ namespace docopt {
 	/// @throws DocoptExitHelp if 'help' is true and the user has passed the '--help' argument
 	/// @throws DocoptExitVersion if 'version' is true and the user has passed the '--version' argument
 	/// @throws DocoptArgumentError if the user's argv did not match the usage patterns
-	std::map<std::string, value> docopt_parse(std::string const& doc,
+    std::map<std::string, value> DOCOPT_API docopt_parse(std::string const& doc,
 					    std::vector<std::string> const& argv,
 					    bool help = true,
 					    bool version = true,
@@ -61,7 +80,7 @@ namespace docopt {
 	///  * DocoptExitHelp - print usage string and terminate (with exit code 0)
 	///  * DocoptExitVersion - print version and terminate (with exit code 0)
 	///  * DocoptArgumentError - print error and usage string and terminate (with exit code -1)
-	std::map<std::string, value> docopt(std::string const& doc,
+	std::map<std::string, value> DOCOPT_API docopt(std::string const& doc,
 					    std::vector<std::string> const& argv,
 					    bool help = true,
 					    std::string const& version = {},


### PR DESCRIPTION
In PR #60, I tried to improve support for using docopt with Visual Studio when building/using the shared library `docopt.dll`. In doing so, I introduced a bug when trying to build/use docopt as a *static* library (`docopt_s.lib`) in Visual Studio.

Basically, I had been defining `DOCOPTAPI` to be `__declspec(dllimport)` when building the static library. But when building a static library, neither `__declspec(dllimport)` nor `__declspec(dllexport)` should be used. 

This PR fixes the bug. The new behavior is as follows. When *building* the shared library, one must define both `DOCOPT_DLL` and `DOCOPT_API`. When *using* the shared library, one must define `DOCOPT_DLL`. The user need not worry about these macros at all; they are handled by CMake. For example, a client project with the following CMakeLists.txt will cause `DOCOPT_DLL` to automatically be defined when compiling `foo.cpp`.

```cmake
project(ClientToDocopt)
cmake_minimum_required(VERSION 3.1)
find_package(docopt)
add_executable(foo foo.cpp)
target_link_libraries(foo docopt)
```

Locally, I tested both the shared library `docopt.dll` and the static library `docopt_s.lib` with a small CMake client project.