### PR TITLE
Run clang-tidy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,10 @@ docopt-config-version.cmake
 
 # Files configured by CMake
 run_tests
+
+# CLion cruft
+.idea/
+cmake-build-debug/
+
+# Separate build directory
+build/

--- a/docopt_value.h
+++ b/docopt_value.h
@@ -21,7 +21,7 @@ namespace docopt {
 	/// This type can be one of: {bool, long, string, vector<string>}, or empty.
 	struct value {
 		/// An empty value
-		value() {}
+		value() = default;
 
 		value(std::string);
 		value(std::vector<std::string>);
@@ -67,10 +67,10 @@ namespace docopt {
 		};
 		
 		union Variant {
-			Variant() {}
+			Variant() = default;
 			~Variant() {  /* do nothing; will be destroyed by ~value */ }
 			
-			bool boolValue;
+			bool boolValue{};
 			long longValue;
 			std::string strValue;
 			std::vector<std::string> strList;


### PR DESCRIPTION
From the top-level:

mkdir build && cd build

cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..

`locate run-clang-tidy.py` -header-filter='.*'
-checks='-*,clang-analyzer-c*,clang-analyzer-deadcode*,clang-analyzer-nu
ll*,clang-analyzer-security*,cppcoreguidelines-*,modernize-*,performance
-*' -fix

Then discard those changes Jared doesn’t like. :smiley: