### PR TITLE
cmake: export build directory targets and add to CMake's package registry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,14 @@ write_basic_package_version_file("${PROJECT_BINARY_DIR}/docopt-config-version.cm
 install(FILES docopt-config.cmake ${PROJECT_BINARY_DIR}/docopt-config-version.cmake DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/docopt")
 install(EXPORT ${export_name} DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/docopt")
 
+# build directory project config
+export(EXPORT ${export_name}
+	FILE docopt-config.cmake
+)
+
+# add packe to CMake registry
+export(PACKAGE docopt)
+
 #============================================================================
 # CPack
 #============================================================================


### PR DESCRIPTION
This enables other projects to use docopt via "find_package()" whithout installing the docopt package itself. See cmake [documentation](https://cmake.org/cmake/help/v3.7/command/export.html?highlight=export) for further info in this.