### PR TITLE
Add super minimal meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,7 @@ docopt_headers = [ 'docopt.h',
                    'docopt_value.h']
 
 stdlib_includes = []
-if meson.is_cross_build()
+if host_machine.system() == 'android'
   stdlib_includes += include_directories(
     [join_paths(meson.get_cross_property('stdlib_rootdir'), 'include'),
      join_paths(meson.get_cross_property('stdlib_rootdir'), 'libs/armeabi-v7a/include'),

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,16 @@
+project('docopt', 'cpp', version : '0.6.2',
+        default_options : ['cpp_std=c++11'])
+
+
+docopt_sources = ['docopt.cpp']
+docopt_headers = [ 'docopt.h',
+                   'docopt_private.h',
+                   'docopt_util.h',
+                   'docopt_value.h']
+		
+docopt_inc = include_directories('..')
+docopt_lib = static_library('docopt', sources : [docopt_sources, docopt_headers],
+                           include_directories : docopt_inc)
+
+docopt_dep = declare_dependency(link_with : docopt_lib,
+                                include_directories : docopt_inc)

--- a/meson.build
+++ b/meson.build
@@ -7,10 +7,18 @@ docopt_headers = [ 'docopt.h',
                    'docopt_private.h',
                    'docopt_util.h',
                    'docopt_value.h']
-		
+
+stdlib_includes = []
+if meson.is_cross_build()
+  stdlib_includes += include_directories(
+    [join_paths(meson.get_cross_property('stdlib_rootdir'), 'include'),
+     join_paths(meson.get_cross_property('stdlib_rootdir'), 'libs/armeabi-v7a/include'),
+     '/Users/germandiago/android/crystax-ndk-10.3.2/platforms/android-19/arch-arm/usr/include'])
+endif
+
 docopt_inc = include_directories('..')
 docopt_lib = static_library('docopt', sources : [docopt_sources, docopt_headers],
-                           include_directories : docopt_inc)
+                           include_directories : [docopt_inc, stdlib_includes])
 
 docopt_dep = declare_dependency(link_with : docopt_lib,
                                 include_directories : docopt_inc)


### PR DESCRIPTION
This just supports a static library target.
Only tested in Mac OS as of now. Should work
in linux/unix-like too AFAIK.

I needed this for my own project. Eventually full support could be added and a wrap file for meson as well. See here: http://mesonbuild.com/Using-the-WrapDB.html