### PR TITLE
Add version property to targets in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,9 @@ else()
     add_library(docopt_s STATIC $<TARGET_OBJECTS:docopt_o>)
 endif()
 
+set_property(TARGET docopt PROPERTY VERSION ${PROJECT_VERSION})
+set_property(TARGET docopt_s PROPERTY VERSION ${PROJECT_VERSION})
+
 target_include_directories(docopt PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}> $<INSTALL_INTERFACE:include/docopt>)
 target_include_directories(docopt_s PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}> $<INSTALL_INTERFACE:include/docopt>)
 


### PR DESCRIPTION
This allows CMake to create versioned .so and .a files.

This is needed in order to integrate docopt.cpp in open-embedded with a bitbake recipe like this:

```
DESCRIPTION = "docopt creates beautiful command-line interfaces"
HOMEPAGE = "https://github.com/docopt/docopt.cpp"
LICENSE = "MIT"
LIC_FILES_CHKSUM = "file://LICENSE-MIT;md5=4b242fd9ef20207e18286d73da8a6677 \
                   "
DEPENDS = ""
PR = "r0"
SRC_URI = "git://github.com/docopt/docopt.cpp.git;protocol=https;branch=master;rev=v0.6.2"

S = "${WORKDIR}/git"

inherit pkgconfig cmake
```

Non versioned library files result in this bitbake error:

`ERROR: docopt.cpp-0.6.2-r0 do_package_qa: QA Issue: -dev package contains non-symlink .so...`