### PR TITLE
Bazel support

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,22 @@
+# -*- python -*-
+
+# This makes
+#
+#  #include "docopt.cpp/docopt.h"
+#
+# do the right thing, which is also as near as I can tell the
+# recommended Bazel style (ie. prefixing the header with the
+# library name.)
+cc_library(
+    name = "docopt",
+    hdrs = ["docopt.h"],
+    srcs = [
+        "docopt.h",
+        "docopt_value.h",
+        "docopt_util.h",
+        "docopt_private.h",
+        "docopt.cpp"
+    ],
+    include_prefix = "docopt.cpp",
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Given this,

WORKSPACE:
http_archive(
    name = "docopt_cpp",
    url = "http://github.com/nikodemus/docopt.cpp/zipball/bazel-support/",
    sha256 = "a7f191ae531994069680b4fd20a6d310246dc980c18db35f92a31bbfde45bed6",
    strip_prefix = "nikodemus-docopt.cpp-47c7302",
    type = "zip",
)

BUILD:
cc_binary(
    name = "example",
    srcs = ["example.cpp"],
    deps = ["@docopt_cpp//:docopt"],
)

type things will just work to use #include "docopt.cpp/docopt.h" in example.cpp.

(Except of course with the upstream repo instead of my fork.)

