### PR TITLE
Add missing <stdexcept> include to use std::runtime_error

### DIFF
--- a/docopt_value.h
+++ b/docopt_value.h
@@ -9,6 +9,7 @@
 #ifndef docopt__value_h_
 #define docopt__value_h_
 
+#include <stdexcept>
 #include <string>
 #include <vector>
 #include <functional> // std::hash


### PR DESCRIPTION
This causes compile failures with VS2019 previews, Add \<stdexcept> include to use runtime_error.