### PR TITLE
Add pkgconfig support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,9 @@ write_basic_package_version_file("${PROJECT_BINARY_DIR}/docopt-config-version.cm
 install(FILES docopt-config.cmake ${PROJECT_BINARY_DIR}/docopt-config-version.cmake DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/docopt")
 install(EXPORT ${export_name} DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/docopt")
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/docopt.pc.in ${CMAKE_CURRENT_BINARY_DIR}/docopt.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/docopt.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
 #============================================================================
 # CPack
 #============================================================================

--- a/docopt.pc.in
+++ b/docopt.pc.in
@@ -1,0 +1,9 @@
+libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
+includedir=@CMAKE_INSTALL_PREFIX@/include/docopt
+
+Name: docopt.cpp
+Description: C++11 port of docopt
+Version: @PROJECT_VERSION@
+Requires:
+Libs: -L${libdir} -ldocopt
+Cflags: -I${includedir}

--- a/docopt.pc.in
+++ b/docopt.pc.in
@@ -1,9 +1,8 @@
-libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
-includedir=@CMAKE_INSTALL_PREFIX@/include/docopt
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: docopt.cpp
 Description: C++11 port of docopt
 Version: @PROJECT_VERSION@
-Requires:
 Libs: -L${libdir} -ldocopt
 Cflags: -I${includedir}


### PR DESCRIPTION
Hello,

This PR adds the generation of a [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/) file for docopt when calling `make/ninja/etc. install`. Merging it should close #68.

In brief, pkg-config eases the utilization of software libraries by allowing the developers of a library to define how the library should be used — instead of letting end users struggling with it. It therefore allows docopt users to link/include it without having to know internal details such as include path or the library name.

Some build systems support the definition of dependencies via pkg-config (e.g., this is the main way to define dependencies in [Meson](https://mesonbuild.com/), CMake can use pkg-config dependencies).

I added some fixes over 849e261 (#68) to make it work on non-Debian-based systems.