### PR TITLE
Fix build errors when targeting the Android API 14 or older

### DIFF
--- a/docopt.cpp
+++ b/docopt.cpp
@@ -17,6 +17,7 @@
 #include <unordered_map>
 #include <map>
 #include <string>
+#include <sstream>
 #include <iostream>
 #include <cassert>
 #include <cstddef>
@@ -305,9 +306,10 @@ static PatternList parse_short(Tokens& tokens, std::vector<Option>& options)
 		}
 
 		if (similar.size() > 1) {
-			std::string error = shortOpt + " is specified ambiguously "
-			+ std::to_string(similar.size()) + " times";
-			throw Tokens::OptionError(std::move(error));
+			std::stringstream error;
+			error << shortOpt << " is specified ambiguously "
+				  << similar.size() << " times";
+			throw Tokens::OptionError(std::move(error.str()));
 		} else if (similar.empty()) {
 			options.emplace_back(shortOpt, "", 0);
 

--- a/docopt_value.h
+++ b/docopt_value.h
@@ -14,6 +14,7 @@
 #include <vector>
 #include <functional> // std::hash
 #include <iosfwd>
+#include <cstdlib>
 
 namespace docopt {
 
@@ -280,9 +281,9 @@ namespace docopt {
 		// Attempt to convert a string to a long
 		if (kind == Kind::String) {
 			const std::string& str = variant.strValue;
-			std::size_t pos;
-			const long ret = stol(str, &pos); // Throws if it can't convert
-			if (pos != str.length()) {
+			char* pos;
+			const long ret = std::strtol(str.c_str(), &pos, 10);
+			if (*pos != 0) {
 				// The string ended in non-digits.
 				throw std::runtime_error( str + " contains non-numeric characters.");
 			}


### PR DESCRIPTION
It seems that the Android NDK doesn't fully support the C++11 standard, at least when targeting older API levels.

I've replaced some string <-> integer functions with older implementations to workaround the Android NDK limitations.