### PR TITLE
Install versioned library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,10 @@ else()
     set_target_properties(docopt_o PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 
     add_library(docopt SHARED $<TARGET_OBJECTS:docopt_o>)
+	set_target_properties(docopt PROPERTIES
+			VERSION ${PROJECT_VERSION}
+			SOVERSION ${PROJECT_VERSION_MAJOR}
+			)
     add_library(docopt_s STATIC $<TARGET_OBJECTS:docopt_o>)
 endif()
 


### PR DESCRIPTION
# Note

The library maintainers should review and consider **when the library ABI changes**. Substitute appropriate value for `SOVERSION`

### Commit

* Set library VERSION and SOVERSION

With soversion and version specified, `install` target will install the
library with the specified version and also create the proper symlink.

### Change

`make install` before:
```
libdocopt.so
```

`make install` after:
```
libdocopt.so -> libdocopt.so.0
libdocopt.so.0 -> libdocopt.so.0.6.2
libdocopt.so.0.6.2
```

Fixes #111.