### PR TITLE
Include definition for std::runtime_error

### DIFF
--- a/docopt.h
+++ b/docopt.h
@@ -14,6 +14,7 @@
 #include <map>
 #include <vector>
 #include <string>
+#include <stdexcept>
 
 #ifdef DOCOPT_HEADER_ONLY
     #define DOCOPT_INLINE inline

--- a/docopt_value.h
+++ b/docopt_value.h
@@ -14,6 +14,7 @@
 #include <vector>
 #include <functional> // std::hash
 #include <iosfwd>
+#include <stdexcept>
 
 namespace docopt {
 


### PR DESCRIPTION
Build fails with GCC 10.0. Make sure runtime_error definition is
included in headers that contain construction of std::runtime_error.