### PR TITLE
remove redundant include stdexcept

### DIFF
--- a/docopt_value.h
+++ b/docopt_value.h
@@ -9,7 +9,6 @@
 #ifndef docopt__value_h_
 #define docopt__value_h_
 
-#include <stdexcept>
 #include <string>
 #include <vector>
 #include <functional> // std::hash


### PR DESCRIPTION
docopt_value.h includes stdexcept twice, lines 12 and 17