### PR TITLE
Declare single library in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,28 +34,12 @@ set(docopt_HEADERS
 #============================================================================
 # Compile targets
 #============================================================================
-if(MSVC OR XCODE)
-    # MSVC requires __declspec() attributes, which are achieved via the 
-    # DOCOPT_DLL and DOCOPT_EXPORTS macros below. Since those macros are only
-    # defined when building a shared library, we must build the shared and
-    # static libraries completely separately.
-    # Xcode does not support libraries with only object files as sources.
-    # See https://cmake.org/cmake/help/v3.0/command/add_library.html?highlight=add_library
-    add_library(docopt SHARED ${docopt_SOURCES} ${docopt_HEADERS})
-    add_library(docopt_s STATIC ${docopt_SOURCES} ${docopt_HEADERS})
-else()
-    # If not using MSVC or Xcode, we will create an intermediate object target
-    # to avoid compiling the source code twice.
-    add_library(docopt_o OBJECT ${docopt_SOURCES} ${docopt_HEADERS})
-    set_target_properties(docopt_o PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
-
-    add_library(docopt SHARED $<TARGET_OBJECTS:docopt_o>)
-	set_target_properties(docopt PROPERTIES
-			VERSION ${PROJECT_VERSION}
-			SOVERSION ${PROJECT_VERSION_MAJOR}
-			)
-    add_library(docopt_s STATIC $<TARGET_OBJECTS:docopt_o>)
-endif()
+add_library(docopt ${docopt_SOURCES} ${docopt_HEADERS})
+set_target_properties(docopt PROPERTIES
+    POSITION_INDEPENDENT_CODE TRUE
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR}
+    )
 
 target_include_directories(docopt PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}> $<INSTALL_INTERFACE:include/docopt>)
 target_include_directories(docopt_s PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}> $<INSTALL_INTERFACE:include/docopt>)
@@ -69,11 +53,6 @@ if(MSVC)
                                       PRIVATE DOCOPT_EXPORTS)
 endif()
 
-if(NOT MSVC)
-	set_target_properties(docopt PROPERTIES OUTPUT_NAME docopt)
-	set_target_properties(docopt_s PROPERTIES OUTPUT_NAME docopt)
-endif()
-
 if(USE_BOOST_REGEX)
 	add_definitions("-DDOCTOPT_USE_BOOST_REGEX")
 	# This is needed on Linux, where linking a static library into docopt.so
@@ -82,9 +61,6 @@ if(USE_BOOST_REGEX)
     find_package(Boost 1.53 REQUIRED COMPONENTS regex)
     include_directories(${Boost_INCLUDE_DIRS})
     target_link_libraries(docopt ${Boost_LIBRARIES})
-	if(WITH_STATIC)
-		target_link_libraries(docopt_s ${Boost_LIBRARIES})
-	endif()
 endif()
 
 #============================================================================


### PR DESCRIPTION
Fixes #104 

This replaces 2 libraries declared in CMake: docopt (SHARED) and
docopt_s (STATIC) with single one docopt which can be built as static or
shared depending on -DBUILD_SHARED_LIBS=ON/OFF.