### PR TITLE
Fixes option parsing on C++ libs that match EOL differently

### DIFF
--- a/docopt.cpp
+++ b/docopt.cpp
@@ -171,7 +171,7 @@ static std::vector<std::string> parse_section(std::string const& name, std::stri
 		"(?:^|\\n)"  // anchored at a linebreak (or start of string)
 		"("
 		   "[^\\n]*" + name + "[^\\n]*(?=\\n?)" // a line that contains the name
-		   "(?:\\n[ \\t].*?(?=\\n|$))*"         // followed by any number of lines that are indented
+		   "(?:\\n*[ \\t].*?(?=\\n|$))*"         // followed by any number of blank lines, or lines that are indented
 		")",
 		std::regex::icase
 	};

--- a/docopt_private.h
+++ b/docopt_private.h
@@ -532,7 +532,7 @@ namespace docopt {
 			options_end = option_description.begin() + static_cast<std::ptrdiff_t>(double_space);
 		}
 
-		static const std::regex pattern {"(-{1,2})?(.*?)([,= ]|$)"};
+		static const std::regex pattern {"(-{1,2})?(.*?)([,= ]|$|\n)"};
 		for(std::sregex_iterator i {option_description.begin(), options_end, pattern, std::regex_constants::match_not_null},
 			   e{};
 			i != e;


### PR DESCRIPTION
The following fragment does not match between docopt.cpp and docopt:

    Usage:
        myprog [options] <command> <arguments>...

    Options:
      --reallylongoption <super_long_argument_description>
                    This option fails to capture the argument on some
                    C++ libs where $ does not match EOL.
                    See https://stackoverflow.com/questions/39645660/stdregex-to-match-begin-end-of-string
                    For some discussion and the inspiration to fix it by adding the \n.