### PR TITLE
Improve docopt-config.cmake in case of Boost regex

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,8 +125,12 @@ install(FILES ${docopt_HEADERS} DESTINATION include/docopt)
 
 # CMake Package
 include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  docopt-config.cmake.in
+  "${CMAKE_CURRENT_BINARY_DIR}/docopt-config.cmake"
+  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/docopt")
 write_basic_package_version_file("${PROJECT_BINARY_DIR}/docopt-config-version.cmake" COMPATIBILITY SameMajorVersion)
-install(FILES docopt-config.cmake ${PROJECT_BINARY_DIR}/docopt-config-version.cmake DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/docopt")
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/docopt-config.cmake" ${PROJECT_BINARY_DIR}/docopt-config-version.cmake DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/docopt")
 install(EXPORT ${export_name} DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/docopt")
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/docopt.pc.in ${CMAKE_CURRENT_BINARY_DIR}/docopt.pc @ONLY)

--- a/docopt-config.cmake
+++ b/docopt-config.cmake
@@ -1,1 +1,0 @@
-include("${CMAKE_CURRENT_LIST_DIR}/docopt-targets.cmake")

--- a/docopt-config.cmake.in
+++ b/docopt-config.cmake.in
@@ -1,0 +1,10 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+if(@USE_BOOST_REGEX@)
+  find_dependency(Boost 1.53 COMPONENTS regex)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/docopt-targets.cmake")
+
+check_required_components(docopt)


### PR DESCRIPTION
This commit declares the transitive dependency to Boost in case docopt is build with Boost regex support. In this way, the user doesn't need to declare the dependency to Boost manually.