### PR TITLE
Support python3 for running tests

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 import re
 import sys
@@ -56,17 +56,17 @@ for _, doc, cases in parse_test(tests):
 
 		failures += 1
 
-		print "="*40
-		print doc
-		print ':'*20
-		print prog, argv
-		print '-'*20
+		print("="*40)
+		print(doc)
+		print(':'*20)
+		print(prog, argv)
+		print('-'*20)
 		if out:
-			print out
-		print error
+			print(out)
+		print(error)
 
 if failures:
-	print "%d failures" % failures
+	print("%d failures" % failures)
 	sys.exit(1)
 else:
-	print "PASS (%d)" % passes
+	print("PASS (%d)" % passes)


### PR DESCRIPTION
Simple change done by 2to3 python tool. Make prints compatible with both
python3 and python2.

Change default version to python3. Still can be run by python2
run_tests.py.

Signed-off-by: Petr Mensik <pemensik@redhat.com>