### PR TITLE
Move return so that switch has default case

### DIFF
--- a/docopt_value.h
+++ b/docopt_value.h
@@ -85,8 +85,8 @@ namespace docopt {
 				case Kind::Long: return "long";
 				case Kind::String: return "string";
 				case Kind::StringList: return "string-list";
+				default: return "unknown";
 			}
-			return "unknown";
 		}
 
 		void throwIfNotKind(Kind expected) const {


### PR DESCRIPTION
### Commit

* Move return so that switch has default case

When a project using docopt.cpp is built with `-Werror=switch-default`
option, there's an error
```
error: switch missing default case [-Werror=switch-default]
```
which this fixes.

Signed-off-by: Eero Aaltonen <eero.aaltonen@vaisala.com>