### PR TITLE
Increase cmake_minimum_required to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project(docopt.cpp VERSION 0.6.2)
 
 include(GNUInstallDirs)

--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ Alternatively manual installation is done using (unix)::
 To link *docopt.cpp*, the simplest is to use CMake. The general structure of your
 ``CMakeLists.txt`` would be as follows::
 
-    cmake_minimum_required(VERSION 3.1)
+    cmake_minimum_required(VERSION 3.5)
 
     project(example)
 


### PR DESCRIPTION
Increase `cmake_minimum_required` to address the below warning when building on CMake version 3.27 on Debian `unstable`:

```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
Compatibility with CMake < 3.5 will be removed from a future version of
CMake.
```

### Commit

* Increase cmake_minimum_required to 3.5

CMake version 3.27 deprecates compatibility with versions older than 3.5. Increase the minimum required so that the project can be built without warnings.